### PR TITLE
Disabling joining of sub transactions

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -3,4 +3,4 @@ com.atomikos.icatch.output_dir=${jta.log.directory}/fieldbook/debug/
 com.atomikos.icatch.log_base_dir=${jta.log.directory}/fieldbook/transactions/
 com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServiceFactory
 com.atomikos.icatch.console_log_level=WARN
-
+com.atomikos.icatch.serial_jta_transactions=false


### PR DESCRIPTION
Have updated the jta.properties so that we never attempt to create or join sub transactions.
MySQL does not support sub transactions and which results in errors when the application tries to create a
sub transaction. Further details can be found http://www.atomikos.com/Documentation/KnownProblems#MySQL_XA_bug

issue: BMS-1374
reviewer: MatthewB
