### PR TITLE
BMS-1389 Make design import variable mapping case insensitive

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/service/impl/DesignImportServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/service/impl/DesignImportServiceImpl.java
@@ -280,7 +280,7 @@ public class DesignImportServiceImpl implements DesignImportService {
 		}
 		  
 		for (DesignHeaderItem item : designHeaders) {
-			List<StandardVariable> match = variables.get(item.getName());
+			List<StandardVariable> match = variables.get(item.getName().toUpperCase());
 
 			if (null != match && !match.isEmpty() && null != mappedDesignHeaders.get(match.get(0).getPhenotypicType())) {
 				StandardVariable standardVariable = match.get(0);

--- a/src/test/java/com/efficio/fieldbook/web/common/service/impl/DesignImportServiceImplTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/service/impl/DesignImportServiceImplTest.java
@@ -208,6 +208,19 @@ public class DesignImportServiceImplTest {
 	}
 
 	@Test
+	public void testCategorizeHeadersByPhenotypeIfCaseInsensitive() {
+
+		final Map<PhenotypicType, List<DesignHeaderItem>> result =
+				this.service.categorizeHeadersByPhenotype(this.createUnmappedHeadersWithWrongCase());
+
+		Assert.assertEquals("Total No of TRIAL in file is 2", 2, result.get(PhenotypicType.TRIAL_ENVIRONMENT).size());
+		Assert.assertEquals("Total No of GERMPLASM FACTOR in file is 1", 1, result.get(PhenotypicType.GERMPLASM).size());
+		Assert.assertEquals("Total No of DESIGN FACTOR in file is 3", 3, result.get(PhenotypicType.TRIAL_DESIGN).size());
+		Assert.assertEquals("Total No of VARIATE in file is 0", 0, result.get(PhenotypicType.VARIATE).size());
+
+	}
+
+	@Test
 	public void testConvertToStandardVariables() {
 
 		final Workbook workbook = WorkbookDataUtil.getTestWorkbookForTrial(10, 3);
@@ -915,6 +928,19 @@ public class DesignImportServiceImplTest {
 		items.add(this.createDesignHeaderItem(TermId.PLOT_NO.getId(), "PLOT_NO", 3));
 		items.add(this.createDesignHeaderItem(TermId.REP_NO.getId(), "REP_NO", 4));
 		items.add(this.createDesignHeaderItem(TermId.BLOCK_NO.getId(), "BLOCK_NO", 5));
+
+		return items;
+	}
+
+	private List<DesignHeaderItem> createUnmappedHeadersWithWrongCase() {
+		final List<DesignHeaderItem> items = new ArrayList<>();
+
+		items.add(this.createDesignHeaderItem(TermId.TRIAL_INSTANCE_FACTOR.getId(), "TriAL_iNSTANCE", 0));
+		items.add(this.createDesignHeaderItem(TermId.SITE_NAME.getId(), "SiTe_NaME", 1));
+		items.add(this.createDesignHeaderItem(TermId.ENTRY_NO.getId(), "ENtRY_nO", 2));
+		items.add(this.createDesignHeaderItem(TermId.PLOT_NO.getId(), "PLoT_NO", 3));
+		items.add(this.createDesignHeaderItem(TermId.REP_NO.getId(), "ReP_nO", 4));
+		items.add(this.createDesignHeaderItem(TermId.BLOCK_NO.getId(), "BLoCK_nO", 5));
 
 		return items;
 	}


### PR DESCRIPTION
Kindly review. The only chage is comparing the headers in uppercase as it is the one returned by middleware.
