### PR TITLE
BMS-1771 - Retrieval of variable usage should be optional as this is an expensiv…

### DIFF
--- a/src/main/java/com/efficio/fieldbook/service/FieldbookServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/service/FieldbookServiceImpl.java
@@ -265,7 +265,7 @@ public class FieldbookServiceImpl implements FieldbookService {
 
 	@Override
 	public List<ValueReference> getAllPossibleValues(int id) {
-		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true);
+		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true, false);
 
 		assert !Objects.equals(variable, null);
 
@@ -274,7 +274,7 @@ public class FieldbookServiceImpl implements FieldbookService {
 
 	@Override
 	public List<ValueReference> getAllPossibleValues(int id, boolean isGetAllRecords) {
-		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true);
+		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true, false);
 
 		assert !Objects.equals(variable, null);
 
@@ -371,7 +371,7 @@ public class FieldbookServiceImpl implements FieldbookService {
 
 	@Override
 	public List<ValueReference> getAllPossibleValuesFavorite(int id, String programUUID) {
-		Variable variable = this.ontologyVariableDataManager.getVariable(programUUID, id, true);
+		Variable variable = this.ontologyVariableDataManager.getVariable(programUUID, id, true, false);
 		assert !Objects.equals(variable, null);
 
 		List<ValueReference> possibleValuesFavorite = null;
@@ -484,7 +484,7 @@ public class FieldbookServiceImpl implements FieldbookService {
 
 	@Override
 	public String getValue(int id, String valueOrId, boolean isCategorical) {
-		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true);
+		Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), id, true, false);
 		assert !Objects.equals(variable, null);
 
 		List<ValueReference> possibleValues = this.possibleValuesCache.getPossibleValues(id);

--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ManageSettingsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ManageSettingsController.java
@@ -182,7 +182,7 @@ public class ManageSettingsController extends SettingsController {
 			@ModelAttribute("variableDetails") OntologyDetailsForm variableDetails) {
 		try {
 			Variable ontologyVariable =
-					this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, true);
+					this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, true, false);
 
 			if (!Objects.equals(ontologyVariable, null)) {
 				variableDetails.setVariable(ontologyVariable);
@@ -200,7 +200,7 @@ public class ManageSettingsController extends SettingsController {
 	public String getOntologyUsageDetails(@PathVariable Integer variableId, @PathVariable Integer variableTypeId,
 			@ModelAttribute("variableDetails") OntologyDetailsForm form, Model model) {
 		try {
-			Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, true);
+			Variable variable = this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, true, false);
 
 			if (variable != null && variable.getName() != null && !"".equals(variable.getName())) {
 				form.setProjectCount(ontologyService.countProjectsByVariable(variableId));

--- a/src/main/java/com/efficio/fieldbook/web/common/service/impl/ExportGermplasmListServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/service/impl/ExportGermplasmListServiceImpl.java
@@ -144,7 +144,7 @@ public class ExportGermplasmListServiceImpl implements ExportGermplasmListServic
 					if (!settingDetail.isHidden() && isVisible != null && isVisible) {
 						Integer variableId = settingDetail.getVariable().getCvTermId();
 						Variable variable =
-								this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, false);
+								this.ontologyVariableDataManager.getVariable(this.contextUtil.getCurrentProgramUUID(), variableId, false, false);
 						standardVariableMap.put(variableId, variable);
 					}
 				}


### PR DESCRIPTION
…e operation

Variable usage statistics is optional via a flag in the API.

Turned of retrieval of these statistics in the Fieldbook as they are never used and a performance burden.

issue: BMS-1771
reviewer: NaymeshM
