### PR TITLE
BMS-1776 - Removing unused code causing performance problems

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/nursery/controller/CreateNurseryController.java
+++ b/src/main/java/com/efficio/fieldbook/web/nursery/controller/CreateNurseryController.java
@@ -80,7 +80,7 @@ public class CreateNurseryController extends SettingsController {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see com.efficio.fieldbook.web.AbstractBaseFieldbookController#getContentName()
 	 */
 	@Override
@@ -110,8 +110,8 @@ public class CreateNurseryController extends SettingsController {
 				Workbook workbook = this.fieldbookMiddlewareService.getStudyVariableSettings(nurseryId, true);
 				this.userSelection.setConstantsWithLabels(workbook.getConstants());
 				this.fieldbookService
-						.createIdNameVariablePairs(workbook, new ArrayList<SettingDetail>(), AppConstants.ID_NAME_COMBINATION.getString(),
-								false);
+				.createIdNameVariablePairs(workbook, new ArrayList<SettingDetail>(), AppConstants.ID_NAME_COMBINATION.getString(),
+						false);
 
 				Dataset dataset = (Dataset) SettingsUtil.convertWorkbookToXmlDataset(workbook);
 				SettingsUtil.convertXmlDatasetToPojo(this.fieldbookMiddlewareService, this.fieldbookService, dataset, this.userSelection,
@@ -218,7 +218,7 @@ public class CreateNurseryController extends SettingsController {
 		String contextParams = ContextUtil.getContextParameterString(contextInfo);
 		SessionUtility.clearSessionData(session,
 				new String[] {SessionUtility.USER_SELECTION_SESSION_NAME, SessionUtility.POSSIBLE_VALUES_SESSION_NAME,
-						SessionUtility.PAGINATION_LIST_SELECTION_SESSION_NAME});
+				SessionUtility.PAGINATION_LIST_SELECTION_SESSION_NAME});
 		form.setProjectId(this.getCurrentProjectId());
 		this.setFormStaticData(form, contextParams);
 		this.assignDefaultValues(form);
@@ -299,7 +299,7 @@ public class CreateNurseryController extends SettingsController {
 
 		studyLevelVariables.addAll(form.getBasicDetails());
 
-		addStudyLevelVariablesFromUserSelectionIfNecessary(studyLevelVariables, userSelection);
+		this.addStudyLevelVariablesFromUserSelectionIfNecessary(studyLevelVariables, this.userSelection);
 
 		this.addNurseryTypeFromDesignImport(studyLevelVariables);
 		this.addExperimentalDesignTypeFromDesignImport(studyLevelVariables);
@@ -317,16 +317,16 @@ public class CreateNurseryController extends SettingsController {
 			this.userSelection.getBaselineTraitsList().addAll(baselineTraitsSession);
 		}
 		//added code to set the role for the variables add
-		SettingsUtil.setSettingDetailRole(VariableType.STUDY_DETAIL.getId(), studyLevelVariables, userSelection, fieldbookMiddlewareService,contextUtil.getCurrentProgramUUID());
-		SettingsUtil.setSettingDetailRole(VariableType.GERMPLASM_DESCRIPTOR.getId(), form.getPlotLevelVariables(), userSelection, fieldbookMiddlewareService,contextUtil.getCurrentProgramUUID());
-		SettingsUtil.setSettingDetailRole(VariableType.TRAIT.getId(), form.getNurseryConditions(), userSelection, fieldbookMiddlewareService,contextUtil.getCurrentProgramUUID());
-		SettingsUtil.setSettingDetailRole(VariableType.TRAIT.getId(), baselineTraits, userSelection, fieldbookMiddlewareService,contextUtil.getCurrentProgramUUID());
+		SettingsUtil.setSettingDetailRole(VariableType.STUDY_DETAIL.getId(), studyLevelVariables, this.userSelection, this.fieldbookMiddlewareService,this.contextUtil.getCurrentProgramUUID());
+		SettingsUtil.setSettingDetailRole(VariableType.GERMPLASM_DESCRIPTOR.getId(), form.getPlotLevelVariables(), this.userSelection, this.fieldbookMiddlewareService,this.contextUtil.getCurrentProgramUUID());
+		SettingsUtil.setSettingDetailRole(VariableType.TRAIT.getId(), form.getNurseryConditions(), this.userSelection, this.fieldbookMiddlewareService,this.contextUtil.getCurrentProgramUUID());
+		SettingsUtil.setSettingDetailRole(VariableType.TRAIT.getId(), baselineTraits, this.userSelection, this.fieldbookMiddlewareService,this.contextUtil.getCurrentProgramUUID());
 
 		Dataset dataset = (Dataset) SettingsUtil
 				.convertPojoToXmlDataset(this.fieldbookMiddlewareService, name, studyLevelVariables, form.getPlotLevelVariables(),
-						baselineTraits, this.userSelection, form.getNurseryConditions(), contextUtil.getCurrentProgramUUID());
+						baselineTraits, this.userSelection, form.getNurseryConditions(), this.contextUtil.getCurrentProgramUUID());
 		SettingsUtil.setConstantLabels(dataset, this.userSelection.getConstantsWithLabels());
-		Workbook workbook = SettingsUtil.convertXmlDatasetToWorkbook(dataset, true, contextUtil.getCurrentProgramUUID());
+		Workbook workbook = SettingsUtil.convertXmlDatasetToWorkbook(dataset, true, this.contextUtil.getCurrentProgramUUID());
 		this.userSelection.setWorkbook(workbook);
 
 		this.createStudyDetails(workbook, form.getBasicDetails(), form.getFolderId(), null);
@@ -633,7 +633,6 @@ public class CreateNurseryController extends SettingsController {
 		}
 
 		model.addAttribute("createNurseryForm", form);
-		model.addAttribute("nurseryList", this.getNurseryList());
 
 		return super.showAjaxPage(model, CreateNurseryController.URL_SETTINGS);
 	}
@@ -828,7 +827,7 @@ public class CreateNurseryController extends SettingsController {
 	protected void setSettingDetailsValueFromVariable(MeasurementVariable var, SettingDetail detail) throws MiddlewareQueryException {
 		if (var.getTermId() == TermId.BREEDING_METHOD_CODE.getId() && var.getValue() != null && !var.getValue().isEmpty()) {
 			// set the value of code to ID for it to be selected in the popup
-			Method method = this.fieldbookMiddlewareService.getMethodByCode(var.getValue(), contextUtil.getCurrentProgramUUID());
+			Method method = this.fieldbookMiddlewareService.getMethodByCode(var.getValue(), this.contextUtil.getCurrentProgramUUID());
 			if (method != null) {
 				detail.setValue(String.valueOf(method.getMid()));
 			} else {
@@ -859,13 +858,13 @@ public class CreateNurseryController extends SettingsController {
 	protected void setLocationVariableValue(SettingDetail detail, MeasurementVariable var) throws MiddlewareQueryException {
 		int locationId = var.getValue() != null && !var.getValue().isEmpty() && NumberUtils.isNumber(var.getValue()) ?
 				Integer.valueOf(var.getValue()) :
-				0;
-		Location location = this.fieldbookMiddlewareService.getLocationById(locationId);
-		if (location != null) {
-			detail.setValue(String.valueOf(location.getLocid()));
-		} else {
-			detail.setValue("");
-		}
+					0;
+				Location location = this.fieldbookMiddlewareService.getLocationById(locationId);
+				if (location != null) {
+					detail.setValue(String.valueOf(location.getLocid()));
+				} else {
+					detail.setValue("");
+				}
 	}
 
 	protected void setFieldbookMiddlewareService(org.generationcp.middleware.service.api.FieldbookService fieldbookMiddlewareService) {

--- a/src/main/java/com/efficio/fieldbook/web/nursery/controller/SettingsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/nursery/controller/SettingsController.java
@@ -152,38 +152,6 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 	}
 
 	/**
-	 * Gets the settings list.
-	 *
-	 * @return the settings list
-	 */
-	@ModelAttribute("nurseryList")
-	public List<StudyDetails> getNurseryList() {
-		try {
-			return this.fieldbookMiddlewareService.getAllLocalNurseryDetails(this.contextUtil.getCurrentProgramUUID());
-		} catch (MiddlewareQueryException e) {
-			SettingsController.LOG.error(e.getMessage(), e);
-		}
-
-		return new ArrayList<>();
-	}
-
-	/**
-	 * Gets the trial list.
-	 *
-	 * @return the trial list
-	 */
-	@ModelAttribute("trialList")
-	public List<StudyDetails> getTrialList() {
-		try {
-			return this.fieldbookMiddlewareService.getAllLocalTrialStudyDetails(this.contextUtil.getCurrentProgramUUID());
-		} catch (MiddlewareQueryException e) {
-			SettingsController.LOG.error(e.getMessage(), e);
-		}
-
-		return new ArrayList<>();
-	}
-
-	/**
 	 * Builds the required factors.
 	 *
 	 * @param requiredFields the required fields
@@ -254,7 +222,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 	 */
 	protected List<SettingDetail> updateRequiredFields(List<Integer> requiredVariables, List<String> requiredVariablesLabel,
 			boolean[] requiredVariablesFlag, List<SettingDetail> variables, boolean hasLabels, String idCodeNameCombination, String role)
-			throws MiddlewareException {
+					throws MiddlewareException {
 
 		// create a map of id and its id-code-name combination
 		Map<String, String> idCodeNameMap = new HashMap<>();
@@ -381,9 +349,9 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 							stdVar.getMethod().getName(), role, stdVar.getDataType().getName(), stdVar.getDataType().getId(),
 							stdVar.getConstraints() != null && stdVar.getConstraints().getMinValue() != null ?
 									stdVar.getConstraints().getMinValue() :
-									null, stdVar.getConstraints() != null && stdVar.getConstraints().getMaxValue() != null ?
-							stdVar.getConstraints().getMaxValue() :
-							null);
+										null, stdVar.getConstraints() != null && stdVar.getConstraints().getMaxValue() != null ?
+												stdVar.getConstraints().getMaxValue() :
+													null);
 			svar.setCvTermId(stdVar.getId());
 			svar.setCropOntologyId(stdVar.getCropOntologyId() != null ? stdVar.getCropOntologyId() : "");
 			svar.setTraitClass(stdVar.getIsA() != null ? stdVar.getIsA().getName() : "");
@@ -433,10 +401,10 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 			var.setDataTypeId(stdvar.getDataType().getId());
 			var.setMinRange(stdvar.getConstraints() != null && stdvar.getConstraints().getMinValue() != null ?
 					stdvar.getConstraints().getMinValue() :
-					null);
+						null);
 			var.setMaxRange(stdvar.getConstraints() != null && stdvar.getConstraints().getMaxValue() != null ?
 					stdvar.getConstraints().getMaxValue() :
-					null);
+						null);
 			var.setWidgetType();
 		}
 	}
@@ -454,10 +422,10 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 			SettingVariable svar = new SettingVariable(stdVar.getName(), stdVar.getDescription(), stdVar.getProperty().getName(),
 					stdVar.getScale().getName(), stdVar.getMethod().getName(), null, stdVar.getDataType().getName(),
 					stdVar.getDataType().getId(), stdVar.getConstraints() != null && stdVar.getConstraints().getMinValue() != null ?
-					stdVar.getConstraints().getMinValue() :
-					null, stdVar.getConstraints() != null && stdVar.getConstraints().getMaxValue() != null ?
-					stdVar.getConstraints().getMaxValue() :
-					null);
+							stdVar.getConstraints().getMinValue() :
+								null, stdVar.getConstraints() != null && stdVar.getConstraints().getMaxValue() != null ?
+										stdVar.getConstraints().getMaxValue() :
+											null);
 			svar.setCvTermId(stdVar.getId());
 			svar.setCropOntologyId(stdVar.getCropOntologyId() != null ? stdVar.getCropOntologyId() : "");
 			svar.setTraitClass(stdVar.getIsA() != null ? stdVar.getIsA().getName() : "");
@@ -476,7 +444,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 	protected StandardVariable getStandardVariable(int id) throws MiddlewareException {
 		StandardVariable variable = this.userSelection.getCacheStandardVariable(id);
 		if (variable == null) {
-			variable = this.fieldbookMiddlewareService.getStandardVariable(id, contextUtil.getCurrentProgramUUID());
+			variable = this.fieldbookMiddlewareService.getStandardVariable(id, this.contextUtil.getCurrentProgramUUID());
 			if (variable != null) {
 				this.userSelection.putStandardVariableInCache(variable);
 			}
@@ -630,7 +598,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 					AppConstants.ID_CODE_NAME_COMBINATION_STUDY.getString());
 			// set value of breeding method code back to code after saving
 			SettingsUtil
-					.resetBreedingMethodValueToId(this.fieldbookMiddlewareService, workbook.getObservations(), false, this.ontologyService);
+			.resetBreedingMethodValueToId(this.fieldbookMiddlewareService, workbook.getObservations(), false, this.ontologyService);
 			// remove selection variates from traits list
 			this.removeSelectionVariatesFromTraits(this.userSelection.getBaselineTraitsList());
 		}
@@ -765,7 +733,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 					}
 				}
 			}
-			String programUUID = contextUtil.getCurrentProgramUUID();
+			String programUUID = this.contextUtil.getCurrentProgramUUID();
 			StringTokenizer tokenizer = new StringTokenizer(idCodeNamePairs, ",");
 			if (tokenizer.hasMoreTokens()) {
 				// we iterate it
@@ -776,7 +744,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 					String codeTermId = tokenizerPair.nextToken();
 					String nameTermId = tokenizerPair.nextToken();
 
-					Method method = getMethod(studyConditionMap, idTermId, codeTermId, programUUID);
+					Method method = this.getMethod(studyConditionMap, idTermId, codeTermId, programUUID);
 
 					// add code to the removed conditions if code is not yet in the list
 					if (studyConditionMap.get(idTermId) != null && studyConditionMap.get(codeTermId) != null
@@ -802,11 +770,11 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 		if (studyConditionMap.get(idTermId) != null) {
 			method = studyConditionMap.get(idTermId).getValue().isEmpty() ?
 					null :
-					this.fieldbookMiddlewareService.getMethodById(Double.valueOf(studyConditionMap.get(idTermId).getValue()).intValue());
+						this.fieldbookMiddlewareService.getMethodById(Double.valueOf(studyConditionMap.get(idTermId).getValue()).intValue());
 		} else if (studyConditionMap.get(codeTermId) != null) {
 			method = studyConditionMap.get(codeTermId).getValue().isEmpty() ?
 					null :
-					this.fieldbookMiddlewareService.getMethodByCode(studyConditionMap.get(codeTermId).getValue(), programUUID);
+						this.fieldbookMiddlewareService.getMethodByCode(studyConditionMap.get(codeTermId).getValue(), programUUID);
 		}
 		return method;
 	}
@@ -945,7 +913,7 @@ public abstract class SettingsController extends AbstractBaseFieldbookController
 
 		if (newSetting == null && createNewSettingIfNull) {
 			try {
-				newSetting = createSettingDetail(variableId, "", "");
+				newSetting = this.createSettingDetail(variableId, "", "");
 				newSetting.getVariable().setOperation(Operation.UPDATE);
 			} catch (MiddlewareQueryException e) {
 				LOG.error(e.getMessage(), e);


### PR DESCRIPTION
The study details query causes performance problems since it selects table scans the whole nd_experiement table. This was mainly due to the use of the hasRows method in the StudyDetails class. This data is actually not needed as it is not used any where in the application.

Removing used code that required this information.

issue: BMS-17776
reviewer: NaymeshM
