### PR TITLE
BMS-1583 Fix Tests, move retrieveTemplate() method to FileService

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/service/impl/CrossingTemplateExcelExporter.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/service/impl/CrossingTemplateExcelExporter.java
@@ -48,9 +48,11 @@ public class CrossingTemplateExcelExporter extends GermplasmExportServiceImpl {
 	@Resource
 	private FileService fileService;
 
+	private String templateFile;
+
 	public File export(Integer studyId, String studyName) throws CrossingTemplateExportException {
 		try {
-			final Workbook excelWorkbook = this.retrieveTemplate();
+			final Workbook excelWorkbook = this.fileService.retrieveWorkbookTemplate(this.templateFile);
 			final Map<String, CellStyle> workbookStyle = this.createStyles(excelWorkbook);
 
 			// 1. parse the workbook to the template file
@@ -102,6 +104,11 @@ public class CrossingTemplateExcelExporter extends GermplasmExportServiceImpl {
 				String.valueOf(germplasmList.getDate()), "Accepted formats: YYYYMMDD or YYYYMM or YYYY or blank");
 
 		return ++actualRow;
+	}
+
+	@Override
+	public void setTemplateFile(final String templateFile) {
+		this.templateFile = templateFile;
 	}
 
 	protected File createExcelOutputFile(String studyName, Workbook excelWorkbook) throws IOException {

--- a/src/test/java/com/efficio/fieldbook/web/common/service/impl/CrossingTemplateExcelExporterTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/service/impl/CrossingTemplateExcelExporterTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -32,6 +33,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.efficio.fieldbook.web.common.exception.CrossingTemplateExportException;
@@ -41,6 +43,7 @@ public class CrossingTemplateExcelExporterTest {
 
 	public static final String STUDYNAME = "studyname";
 	private static final int STUDY_ID = 1;
+	public static final String TEST_FILENAME = "testFilename.xls";
 	@Mock
 	private org.generationcp.middleware.service.api.FieldbookService fieldbookMiddlewareService;
 
@@ -63,8 +66,12 @@ public class CrossingTemplateExcelExporterTest {
 
 	@Before
 	public void setup() throws IOException, InvalidFormatException {
+		MockitoAnnotations.initMocks(this);
+
+		exporter.setTemplateFile(TEST_FILENAME);
+
 		this.DUT = Mockito.spy(this.exporter);
-		InputStream inp = this.getClass().getClassLoader().getResourceAsStream("testFilename.xls");
+		InputStream inp = this.getClass().getClassLoader().getResourceAsStream(TEST_FILENAME);
 
 		this.workbook = WorkbookFactory.create(inp);
 	}
@@ -85,7 +92,7 @@ public class CrossingTemplateExcelExporterTest {
 		Map<String, CellStyle> style = Mockito.mock(Map.class);
 		Mockito.doReturn(style).when(this.DUT).createStyles(wb);
 
-		Mockito.doReturn(wb).when(this.DUT).retrieveTemplate();
+		Mockito.doReturn(wb).when(this.fileService).retrieveWorkbookTemplate(TEST_FILENAME);
 		Mockito.doReturn(4)
 				.when(this.DUT)
 				.writeListDetailsSection(Matchers.any(Map.class), Matchers.any(Sheet.class), Matchers.anyInt(),
@@ -110,7 +117,7 @@ public class CrossingTemplateExcelExporterTest {
 
 	@Test(expected = CrossingTemplateExportException.class)
 	public void testExportException() throws Exception {
-		Mockito.doThrow(new InvalidFormatException("forced exception")).when(this.DUT).retrieveTemplate();
+		Mockito.doThrow(new InvalidFormatException("forced exception")).when(this.fileService).retrieveWorkbookTemplate(TEST_FILENAME);
 
 		this.DUT.export(CrossingTemplateExcelExporterTest.STUDY_ID, CrossingTemplateExcelExporterTest.STUDYNAME);
 


### PR DESCRIPTION
This requires the pull request from Commons to be merged first.

Enabling tests for BreadingManager. 
The review suggested that we move retrieveTemplate() method from GermplasmExportServiceImpl to FileService, which actually does file retrieval.
It also allows us to remove spies in tests for GermplasmExportServiceImpl (review suggestion)
