### PR TITLE
Bms 2094 smth went wrong on create new trial

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/trial-data-manager.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/trial-data-manager.js
@@ -374,7 +374,7 @@
 										$('body').data('needToSave', '0');
 									});
 								} else {
-									showErrorMessage('', 'Trial could not be saved at the moment. Try again later.');
+									showErrorMessage('', 'Trial could not be saved at the moment. Please try again later.');
 								}
 							});
 						} else {


### PR DESCRIPTION
We have updated the angular library and the new version of `$http` by default parses response as json.

For that particular service we are receiving string response `"success"`, and not a json object.
So we set `$http` property `{transformResponce: undefined}` to indicate that the transformation function is not needed for that particular request.
