### PR TITLE
Plot Number Generation Across Environments Fixed

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/service/impl/RandomizeCompleteBlockDesignServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/service/impl/RandomizeCompleteBlockDesignServiceImpl.java
@@ -170,12 +170,7 @@ public class RandomizeCompleteBlockDesignServiceImpl implements RandomizeComplet
 							variates, treatmentVariables, reqVarList, germplasmList, mainDesign, this.workbenchService,
 							this.fieldbookProperties, stdvarTreatment.getName(), treatmentFactorValues, this.fieldbookService);
 
-			if (plotNo != null) {
-				for (MeasurementRow measurementRow : measurementRowList) {
-					measurementRow.getDataList().get(6).setValue(plotNo.toString());
-					plotNo++;
-				}
-			}
+
 		} catch (BVDesignException e) {
 			throw e;
 		} catch (Exception e) {


### PR DESCRIPTION
Plot numbers are now generated correctly in the trial manager. Plot numbers should not be stretch across trial instances i.e. environments. Starting plot number should be applied for each instance. For example we are generating plots for 100 entries and three instances starting at 301. The starting plot number is now 301 for ach instance. Thus our plot numbers 301-400 for each instance.

issue: BMS-1930
reviewer: NaymeshM
