### PR TITLE
BMS-2094SomethingWentWrongOnClearTrialSettingsService

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/manageTrial.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/manageTrial.js
@@ -226,7 +226,15 @@ showAlertMessage,importSaveDataWarningMessage,showMeasurementsPreview,createErro
 				TrialManagerDataService.trialMeasurement = angular.copy($localStorage.serviceBackup.trialMeasurement);
 
 				// perform other cleanup tasks
-				$http.get('/Fieldbook/TrialManager/createTrial/clearSettings');
+				$http({
+					url: '/Fieldbook/TrialManager/createTrial/clearSettings',
+					method: 'GET',
+					transformResponse: undefined
+				}).then(function(response) {
+					if (response.data !== 'success' || response.status !== 200) {
+						showErrorMessage('', 'Your trial settings could not be cleared at the moment. Please try again later.');
+					}
+				});
 
 				var measurementDiv = $('#measurementsDiv');
 				if (measurementDiv.length !== 0) {


### PR DESCRIPTION
We have updated the angular library and the new version of $http by default parses response as json.

For that particular service we are receiving string response "success", and not a json object.
So we set $http property {transformResponce: undefined} to indicate that the transformation function is not needed for that particular request.

Issue: BMS-2094
Reviewer: Matthew
