### PR TITLE
Bms 2108 Fix error in trial for import design

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/trial/controller/BaseTrialController.java
+++ b/src/main/java/com/efficio/fieldbook/web/trial/controller/BaseTrialController.java
@@ -171,8 +171,9 @@ public abstract class BaseTrialController extends SettingsController {
 
 			data.setReplicationsCount(this.getExperimentalDesignData(xpDesignVariable.getNumberOfReplicates()));
 
-			// Set first plot number from observations
-			if (trialWorkbook.getObservations() != null && !trialWorkbook.getObservations().isEmpty()) {
+			// Set first plot number from observations, the 6th element contains the value for the starting plot no
+			if (trialWorkbook.getObservations() != null && !trialWorkbook.getObservations().isEmpty()
+					&& trialWorkbook.getObservations().get(0).getDataList().size() == 7) {
 				data.setStartingPlotNo(trialWorkbook.getObservations().get(0).getDataList().get(6).getValue());
 			}
 


### PR DESCRIPTION
This is just a simple fix the skip the setup of starting plot no when the trial is created from imported design.

Kindly Review! Thanks!
