### PR TITLE
BMS-2121 Fixed the buttons duplication when we use the pagination, as we were …

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
@@ -55,6 +55,10 @@ environmentModalConfirmationText, environmentConfirmLabel, showAlertMessage, loa
 				//temporary fix in buttons disappear bug,
 				//see https://github.com/l-lin/angular-datatables/issues/502#issuecomment-161166246
 				if (api) {
+					// remove old set of buttons before recreating them
+					if (api.buttons()) {
+						api.buttons().remove();
+					}
 					new $.fn.dataTable.Buttons(api, {
 						buttons: $scope.isLocation ? $scope.buttonsTopWithLocation.slice() : $scope.buttonsTop.slice()
 					});


### PR DESCRIPTION
Fixed the buttons duplication when we use the pagination, as we were not deleting the old set of buttons when creating and adding a new set.

Issue: BMS-2121
Reviewer: Matthew
