### PR TITLE
BMS-2193 Remove the buggy Fixed Columns plugin

### DIFF
--- a/src/main/webapp/WEB-INF/pages/template/ng-base-template.html
+++ b/src/main/webapp/WEB-INF/pages/template/ng-base-template.html
@@ -82,7 +82,6 @@
     <script type="text/javascript" th:src="@{/static/js/lib/datatable/angular-datatables.min.js}"></script>
     <script type="text/javascript" th:src="@{/static/js/lib/datatable/dataTables.buttons.min.js}"></script>
     <script type="text/javascript" th:src="@{/static/js/lib/datatable/angular-datatables.buttons.min.js}"></script>
-    <script type="text/javascript" th:src="@{/static/js/lib/datatable/angular-datatables.fixedcolumns.min.js}"></script>
     <script type="text/javascript" th:src="@{/static/js/lib/datatable/buttons.colVis.min.js}"></script>
 
     <!-- FIXME: for the meantime, the legacy chooseSettings.js is needed by fieldbook-utils.js for the old ontology popup  -->

--- a/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
@@ -49,10 +49,7 @@ environmentModalConfirmationText, environmentConfirmLabel, showAlertMessage, loa
 			$scope.dtOptions = DTOptionsBuilder.newOptions().withDOM('<"fbk-datatable-panel-top"liB>rtp')
 				.withButtons($scope.isLocation ? $scope.buttonsTopWithLocation.slice() : $scope.buttonsTop.slice())
 				.withOption('scrollX', true)
-				.withOption('scrollCollapse', true)
-				.withFixedColumns({
-					leftColumns: 2
-				});
+				.withOption('scrollCollapse', true);
 
 			$scope.dtOptions.drawCallback =  function() {
 				var api = $(this).DataTable();

--- a/src/main/webapp/WEB-INF/static/js/trialmanager/manageTrial.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/manageTrial.js
@@ -10,7 +10,7 @@ showAlertMessage,importSaveDataWarningMessage,showMeasurementsPreview,createErro
 
 	var manageTrialApp = angular.module('manageTrialApp', ['designImportApp', 'leafnode-utils', 'fieldbook-utils',
 		'ct.ui.router.extras', 'ui.bootstrap', 'ngLodash', 'ngResource', 'ngStorage', 'datatables', 'datatables.buttons',
-		'datatables.fixedcolumns', 'showSettingFormElementNew']);
+		'showSettingFormElementNew']);
 
 	// HTTP INTERCEPTOR CONFIGURATION START
 	// The following block defines an interceptor that hooks into AJAX operations initiated by Angular to start / stop the spinner operation


### PR DESCRIPTION
Remove the buggy Fixed Columns plugin for angular-datatables, which was breaking the environments datatable.

Issue: BMS-2193
Reviewer: Matthew
