### PR TITLE
BMS-2121 Update the path to the buttons of the environment datatable to reload them

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
@@ -68,7 +68,7 @@ environmentModalConfirmationText, environmentConfirmLabel, showAlertMessage, loa
 						buttons: $scope.isLocation ? $scope.buttonsTopWithLocation.slice() : $scope.buttonsTop.slice()
 					});
 
-					$(this).parent().find('.dt-buttons').replaceWith(api.buttons().container());
+					$(this).parents('.dataTables_wrapper').find('.dt-buttons').replaceWith(api.buttons().container());
 				}
 			};
 


### PR DESCRIPTION
The introduction of horizontal scroll and fixed columns plugin has changed the html layout of the page.

We need to update the path to the buttons of the environment datatable and make it more universal, so that other such changes won't break it.

Issue: BMS-2121
Reviewer: Matthew
