### PR TITLE
BMS-2118 - Fix incorrect starting entry number

### DIFF
--- a/src/main/webapp/WEB-INF/pages/NurseryManager/showGermplasmPagination.html
+++ b/src/main/webapp/WEB-INF/pages/NurseryManager/showGermplasmPagination.html
@@ -129,10 +129,12 @@ function validateAndSetEntryNo() {
 
 function findEntryColIndex(dataTableIdentifier) {
     var entryNoColNum = 0;
-    $("table" + dataTableIdentifier + " thead tr th").each(function (index, value) {
-        var colName = $(this).data("colName");
-        if(colName === '8230-key' || colName === 'entry') {
-            entryNoColNum = $(this).data("columnIndex");
+    var dataTable = $(dataTableIdentifier).dataTable();
+    dataTable.api().columns().every( function (index, value) {
+    	var colHeader = dataTable.api().column(index).header();
+    	var colName = colHeader.attributes["data-col-name"].nodeValue;
+    	if(colName === '8230-key' || colName === 'entry') {
+    		entryNoColNum = colHeader.attributes["data-column-index"].nodeValue;
         }
     });
     return entryNoColNum;
@@ -141,24 +143,28 @@ function findEntryColIndex(dataTableIdentifier) {
 function findLowestEntryNo(dataTableIdentifier, entryNoColIndex) {
     var lowestEntryNo = 0;
     var dataTable = $(dataTableIdentifier).dataTable();
-    $("table" + dataTableIdentifier + " tbody tr").each(function (index, value) {
+    var numberOfRows = dataTable.api().rows().data().length;
+    var index;
+    for(index = 0; index < numberOfRows; index++) {
         var cell = dataTable.api().cell(index, entryNoColIndex);
         var currentEntryNo = cell.data();
         if(lowestEntryNo === 0 || currentEntryNo < lowestEntryNo) {
             lowestEntryNo = parseInt(currentEntryNo);
         }
-    });
+    };
     return lowestEntryNo;
 }
 
 function updateEntryNo(dataTableIdentifier, entryNoColIndex, numToAddToEntryNo) {
     var dataTable = $(dataTableIdentifier).dataTable();
-    $("table" + dataTableIdentifier + " tbody tr").each(function (index, value) {
+    var numberOfRows = dataTable.api().rows().data().length;
+    var index;
+    for(index = 0; index < numberOfRows; index++) {
         var cell = dataTable.api().cell(index, entryNoColIndex);
         var currentEntryNo = cell.data();
         var newEntryNo = parseInt(currentEntryNo) + numToAddToEntryNo;
         cell.data(newEntryNo).draw();
-    });
+    };
 }
 
 // Validate Germplasm entry number and plot number if it is non-numeric


### PR DESCRIPTION
I already fixed the issue of wrong cells updated when starting entry number is changed by always checking the new entry number column index before doing modifications to the data table. Note that it uses the cell.data API to modify the data used in the data table so rearranging the columns and rows and moving to the new tabs will still retain the state of the data table.

Other issues of the generation of design are handled in BMS-2155 - confirmed by testing my fixes merged to that ticket. 
