### PR TITLE
BMS-2205 Fix UI Display in Experimental Design Tab

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/experimentalDesign.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/experimentalDesign.js
@@ -153,6 +153,7 @@
 							$scope.currentParams = EXPERIMENTAL_DESIGN_PARTIALS_LOC + $scope.currentDesignType.params;
 							$scope.data.designType = $scope.currentDesignType.id;
 							TrialManagerDataService.currentData.experimentalDesign.designType = $scope.data.designType;
+							$scope.applicationData.unappliedChangesAvailable = true;
 
 							if ($scope.designTypes[newId].isPreset) {
 								showAlertMessage('', ImportDesign.getMessages().OWN_DESIGN_SELECT_WARNING, 5000);


### PR DESCRIPTION
Make sure that the display in experimental design will not change to "preset design" layout when the user changes tab from experimental design to measurement tab without generating design yet.

Issue: BMS-2205
Reviewer: Cyrus Venn Casada
