### PR TITLE
BMS-2354 Fix Missing Generate Button Design

### DIFF
--- a/src/main/webapp/WEB-INF/pages/TrialManager/templates/experimentalDesignPreset.html
+++ b/src/main/webapp/WEB-INF/pages/TrialManager/templates/experimentalDesignPreset.html
@@ -6,7 +6,7 @@
 				<div ng-include="currentParams"></div>
 				<div class="add_top_padding add-bottom-padding">
 					<input type="submit" class="btn btn-info" value="Generate Design"
-						ng-hide="applicationData.hasGeneratedDesignPreset" />
+						ng-hide="!applicationData.unappliedChangesAvailable &amp;&amp; applicationData.hasGeneratedDesignPreset" />
 				</div>
 			</div>
 			<div class="col-md-6 col-sm-5">


### PR DESCRIPTION
Make sure that the generate design button is not hidden when changing the starting entry no from the germplasm tab

Issue: BMS-2354
Reviewer: Maverick Crisostomo
