### PR TITLE
BMS-2517 Update entry number takes huge time

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/import-germplasm.js
+++ b/src/main/webapp/WEB-INF/static/js/import-germplasm.js
@@ -109,8 +109,9 @@
 					var cell = dataTable.api().cell(index, entryNoColIndex);
 					var currentEntryNo = cell.data();
 					var newEntryNo = parseInt(currentEntryNo) + numToAddToEntryNo;
-					cell.data(newEntryNo).draw();
+					cell.data(newEntryNo);
 				}
+                dataTable.fnDraw();
 			},
 			validateEntryAndPlotNo: function(inputNo) {
 				var validNo = '^(?=.*[1-9].*)[0-9]{1,5}$';


### PR DESCRIPTION
Update entry number takes huge time(for 900 entries it will take near about to 1 minute) because each cell is re-drawn after value update.

Added fix that will redraw datatable instead of each cell.
