### PR TITLE
BMS-2473 Fix merging Issue in Trial Manager

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
@@ -214,11 +214,13 @@ environmentModalConfirmationText, environmentConfirmLabel, showAlertMessage, sho
 						$scope.data.environments.pop();
 					}
 
-					// if the trial has no measurement data regardless if it is saved or not,
-					// regenerate the experimental design and measurement table
-					if ((TrialManagerDataService.isOpenTrial() && !TrialManagerDataService.trialMeasurement.hasMeasurement) ||
+					// If the trial has no measurement data regardless if it is saved or not,
+					// regenerate the experimental design and measurement table.
+					// Also, make sure that the measurement table will only refresh if there is a selected design type for the current trial
+					var designTypeId = TrialManagerDataService.currentData.experimentalDesign.designType;
+					if (designTypeId != null && ((TrialManagerDataService.isOpenTrial() && !TrialManagerDataService.trialMeasurement.hasMeasurement) ||
 							(!TrialManagerDataService.isOpenTrial() &&
-								TrialManagerDataService.currentData.experimentalDesign.noOfEnvironments !== undefined)) {
+								TrialManagerDataService.currentData.experimentalDesign.noOfEnvironments !== undefined))) {
 						refreshMeasurementTableAfterDeletingEnvironment();
 					}
 


### PR DESCRIPTION
2 scenarios fix for this merge:
1. Fix for the js error in environment.js found by Iryna. (related to isPreset)
2. Fix for the delete of environment for an existing trial without measurement data. The main cause of this error is the system tries to regenerate design for measurements whenever the user deletes an environment. We have changed the approach here that instead of regenerating design every time deletion occur, we will just remove the corresponding measurements of the deleted environment.

Kindly review. :)
