### PR TITLE
Bms 2523 fix bugs related to breeding method

### DIFF
--- a/src/main/resources/Messages.properties
+++ b/src/main/resources/Messages.properties
@@ -137,7 +137,7 @@ nursery.import.header.entrycode=Entry Code
 nursery.import.header.parentage=Parentage
 nursery.import.date.required=Date is required
 nursery.import.location.required=Location is required
-nursery.import.method.required=Breeding Method is required
+nursery.import.method.required=For automatic name generation using method based settings the Breeding Method is required.
 
 nursery.fileupload.template.file=Upload a Nursery Template Excel File
 nursery.fileupload.select.template.file=Select Nursery Template File:

--- a/src/main/webapp/WEB-INF/static/js/import-crosses.js
+++ b/src/main/webapp/WEB-INF/static/js/import-crosses.js
@@ -333,8 +333,15 @@ var ImportCrosses = {
 		'use strict';
 		var settingData = ImportCrosses.constructSettingsObjectFromForm();
 
-		if ($('input:radio[name=manualNamingSettings]:checked').val() === 'true') {
+		//perform the validation depending on automated/manual names generation being selected
+		if (settingData.isUseManualSettingsForNaming) {
 			if (!ImportCrosses.isCrossImportSettingsValid(settingData)) {
+				return;
+			}
+		} else {
+			// if automated names generation was selected the breeding method is required
+			if (!settingData.breedingMethodSetting.methodId || settingData.breedingMethodSetting.methodId === '') {
+				showErrorMessage('', $.fieldbookMessages.errorImportMethodRequired);
 				return;
 			}
 		}


### PR DESCRIPTION
The issue were fixed: 
1. If the user tries to import crosses for the 2nd time, even if the 'use breeding method for all option' is not checked (though there is a selected breeding method value), the system still use the previously selected breeding method --- the system now clears the breeding method field each time the window is reopened
2. I am getting something went wrong, please try again, when I want to save the crosses imported list and I have used in Define Crosses Settings the option "Use automathic name generation", and no breeding method selected --- the breeding method is now required if the option "Use automatic name generation" was selected
