### PR TITLE
BMS-2691 Fix Old Value Display in Review Out of Bounds

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/fbk-data-table/fieldbook-datatable.js
+++ b/src/main/webapp/WEB-INF/static/js/fbk-data-table/fieldbook-datatable.js
@@ -432,7 +432,7 @@ BMS.Fieldbook.ReviewDetailsOutOfBoundsDataTable = (function($) {
 				columns.push({
 					data: $(this).html(),
 					render: function(data, type, row) {
-						return EscapeHTML.escape(data);
+						return EscapeHTML.escape((data[0] != null) ? data[0] :  '');
 					}
 				});
 			}


### PR DESCRIPTION
The old value contains a meta data to detect whether it's accepted or not, but it is displayed in the Review Details table.

This change will make sure that only the data is displayed in Old Value column.
