### PR TITLE
BMS 2730 display cropontologyid instead of cvterm

### DIFF
--- a/src/main/webapp/WEB-INF/pages/OntologyBrowser/detailsTab.html
+++ b/src/main/webapp/WEB-INF/pages/OntologyBrowser/detailsTab.html
@@ -64,7 +64,7 @@
 			<div class="col-sm-8 col-xs-10">
 				<p class="form-control-static" >
 					<a id="cropOntologyId" target="_blank" href="http://www.cropontology.org/terms"
-					   th:href="@{http://www.cropontology.org/terms/} + *{variable.id} + '/'" th:text="*{variable.property.cropOntologyId}"></a>
+					   th:href="@{http://www.cropontology.org/terms/} + *{variable.property.cropOntologyId} + '/'" th:text="*{variable.property.cropOntologyId}"></a>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
fixed the broken link for the crop ontology id. kindly merge. Thanks!
