### PR TITLE
BMS-2727 - Call UpdateStartingEntryNoService only if the starting entry no is a number

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/trial-data-manager.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/trial-data-manager.js
@@ -575,7 +575,7 @@
 					//for updating the starting entry number in the server
 					//as the server expects the parameter passed as an Integer
 					//the newCountValue becomes "" or null if the germplasm list is not yet selected for the trial
-					if(!isNaN(parseInt(newCountValue))) {
+					if($.isNumeric(newCountValue)) {
 						UpdateStartingEntryNoService.save(newCountValue);
 					}
 				},


### PR DESCRIPTION
This fixes the Something went wrong error if a trial is created / opened with no list selected. The fix is to only call the UpdateStartingEntryNoService resource if the value passed is a number.

This will also fix BMS-2909. Also note that in BMS-2909 the user will still be able to proceed even if the user encountered an error.
