### PR TITLE
Removed duplicate maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,14 +516,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>-Xmx512m -XX:MaxPermSize=256m</argLine>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This is preventing the jacoco.exec from getting generated. As a result
there were no code coverage report.

issue: none
reviewer: NaymeshM
