### PR TITLE
Bms-3096 Dynamic locale management removal

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -76,6 +76,6 @@
 	</error-page>
 
 	<session-config>
-	    <session-timeout>-1</session-timeout>
+		<session-timeout>60</session-timeout>
 	</session-config>	   
 </web-app>


### PR DESCRIPTION
Set session timeout to 60 minutes. Part of the dynamic locale management removal ticket.

issue: BMS-3096
reviewer: none
