### PR TITLE
BMS-2706 Set trial location in advancing when there's favorite breeding location

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/nurseryManager.js
+++ b/src/main/webapp/WEB-INF/static/js/nurseryManager.js
@@ -226,11 +226,12 @@ function showCorrectLocationCombo() {
 			$('#' + getJquerySafeId('harvestLocationAbbreviation')).val($('#' + getJquerySafeId('harvestLocationIdAll')).select2('data').abbr);
 		}
 
-        //In case of trial we have to set selected location
-        if(!isNursery()){
-            setSelectedLocation();
-        }
 	}
+
+	//In case of trial we have to set selected location
+    if(!isNursery()){
+        setSelectedLocation();
+    }
 }
 
 function showCorrectMethodCombo() {


### PR DESCRIPTION
Call setSelectedLocation for trial even if "favorites only" is checked so that trial condition for location is not lost when advancing using [LABBR] or [CLABBR] process codes

Issue: BMS-2706

Reviewer: Aldrin Batac
