### PR TITLE
BMS-3182 - Added null check before setting selected breeding method id

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/import-crosses.js
+++ b/src/main/webapp/WEB-INF/static/js/import-crosses.js
@@ -510,7 +510,7 @@ var ImportCrosses = {
 		settingObject.breedingMethodSetting = {};
 		settingObject.breedingMethodSetting.methodId = $('#breedingMethodDropdown').select2('val');
 
-		if(selectedBreedingMethodId !== null && selectedBreedingMethodId != ''){
+		if(selectedBreedingMethodId !== null && selectedBreedingMethodId !== 0){
 			settingObject.breedingMethodSetting.methodId = selectedBreedingMethodId;
 		}
 		else if (!settingObject.breedingMethodSetting.methodId || settingObject.breedingMethodSetting.methodId === '') {


### PR DESCRIPTION
This is to prevent breeding method selected to be always null initially and hence raising a validation error. Please review.

Issue: BMS-3182

Reviewer: Aldrin
