### PR TITLE
BMS-3206 Defaulted folder open state stored when closing the Germplasm lists b…

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/controller/GermplasmTreeController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/GermplasmTreeController.java
@@ -90,6 +90,11 @@ import com.google.common.collect.Lists;
 @Transactional
 public class GermplasmTreeController extends AbstractBaseFieldbookController {
 
+	/**
+	 * The default folder open state stored when closing the germplasm lists browser. 
+	 */
+	static final String DEFAULT_STATE_SAVED_FOR_GERMPLASM_LIST = "Lists";
+
 	private static final String COMMON_SAVE_GERMPLASM_LIST = "Common/saveGermplasmList";
 
 	private static final String GERMPLASM_LIST_TYPES = "germplasmListTypes";
@@ -1094,11 +1099,17 @@ public class GermplasmTreeController extends AbstractBaseFieldbookController {
 		final List<String> states = new ArrayList<>();
 		String status = "OK";
 		try {
+			
 			if (!GermplasmTreeController.NODE_NONE.equalsIgnoreCase(expandedNodes[0])) {
 				for (int index = 0; index < expandedNodes.length; index++) {
 					states.add(expandedNodes[index]);
 				}
 			}
+
+			if(states.isEmpty()) {
+				states.add(DEFAULT_STATE_SAVED_FOR_GERMPLASM_LIST);
+			}
+			
 			this.userTreeStateService.saveOrUpdateUserProgramTreeState(this.contextUtil.getCurrentUserLocalId(),
 					this.getCurrentProgramUUID(), type, states);
 		} catch (final MiddlewareQueryException e) {
@@ -1120,7 +1131,7 @@ public class GermplasmTreeController extends AbstractBaseFieldbookController {
 		} else {
 			stateList = this.userTreeStateService.getUserProgramTreeStateByUserIdProgramUuidAndType(userID, programUUID, type);
 		}
-
+		
 		return super.convertObjectToJson(stateList);
 	}
 

--- a/src/test/java/com/efficio/fieldbook/web/common/controller/GermplasmTreeControllerTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/controller/GermplasmTreeControllerTest.java
@@ -57,6 +57,7 @@ import com.efficio.fieldbook.web.common.bean.UserSelection;
 import com.efficio.fieldbook.web.common.form.SaveListForm;
 import com.efficio.fieldbook.web.common.service.impl.CrossingServiceImpl;
 import com.efficio.fieldbook.web.nursery.form.AdvancingNurseryForm;
+import com.google.common.collect.Lists;
 
 import junit.framework.Assert;
 
@@ -275,8 +276,24 @@ public class GermplasmTreeControllerTest {
 		Mockito.doReturn(GermplasmTreeControllerTest.TEST_PROGRAM_UUID).when(this.contextUtil).getCurrentProgramUUID();
 		final String response = this.controller.saveTreeState(ListTreeState.GERMPLASM_LIST.toString(), expandedNodes);
 		Assert.assertEquals("Should return ok", "OK", response);
+		Mockito.verify(userTreeStateService).saveOrUpdateUserProgramTreeState(GermplasmTreeControllerTest.TEST_USER_ID,
+				GermplasmTreeControllerTest.TEST_PROGRAM_UUID, ListTreeState.GERMPLASM_LIST.toString(), Lists.newArrayList("2", "5", "6"));
+
 	}
 
+	@Test
+	public void testSaveTreeStateDefaults() throws MiddlewareQueryException {
+		final String[] expandedNodes = {"None"};
+
+		Mockito.doReturn(GermplasmTreeControllerTest.TEST_USER_ID).when(this.contextUtil).getCurrentUserLocalId();
+		Mockito.doReturn(GermplasmTreeControllerTest.TEST_PROGRAM_UUID).when(this.contextUtil).getCurrentProgramUUID();
+		final String response = this.controller.saveTreeState(ListTreeState.GERMPLASM_LIST.toString(), expandedNodes);
+		Assert.assertEquals("Should return ok", "OK", response);
+		Mockito.verify(userTreeStateService).saveOrUpdateUserProgramTreeState(GermplasmTreeControllerTest.TEST_USER_ID,
+				GermplasmTreeControllerTest.TEST_PROGRAM_UUID, ListTreeState.GERMPLASM_LIST.toString(), 
+				Collections.singletonList(GermplasmTreeController.DEFAULT_STATE_SAVED_FOR_GERMPLASM_LIST));
+	}
+	
 	@Test
 	public void testLoadTreeStateNonSaveDialog() throws MiddlewareQueryException {
 		Mockito.doReturn(GermplasmTreeControllerTest.TEST_USER_ID).when(this.contextUtil).getCurrentUserLocalId();


### PR DESCRIPTION
…rowser

This prevents us from getting into a state where the top level lists are
not expandable as documented in BMS-3206.

issue: BMS-3206
reviewer: Matthewb
