### PR TITLE
BMS-3299 Created list not available in germplasm tree table

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/tree-persist.js
+++ b/src/main/webapp/WEB-INF/static/js/tree-persist.js
@@ -93,7 +93,7 @@ var TreePersist = {
 			async : false,
 			success : function(data) {
 				var expandedNodes = $.parseJSON(data);
-				if((expandedNodes.length == 1 && expandedNodes[0] === '') || expandedNodes.length == 0){
+				if((expandedNodes.length === 1 && expandedNodes[0] === '') || expandedNodes.length === 0){
 					deferred.reject(expandedNodes);
 				} else {
 					deferred.resolve(expandedNodes);


### PR DESCRIPTION
If there's no previous tree state, we have to make sure that the top level LISTS node is expandable and collapsed by default.

BMS-3299
