### PR TITLE
BMS-3209 Added Traits in Measurements Disappear

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/environments.js
@@ -13,8 +13,8 @@ environmentModalConfirmationText, environmentConfirmLabel, showAlertMessage, sho
 			// to make sure deleting environments will still works
 		    // since environments are directly correlated to their measurement rows
 			// NOTE: $rootScope.stateSuccessfullyLoaded will only have value once the specific tab is successfully loaded
-		    if( $rootScope.stateSuccessfullyLoaded['createMeasurements'] == undefined 
-		    		&& $rootScope.stateSuccessfullyLoaded['editMeasurements'] == undefined){
+		    if( $rootScope.stateSuccessfullyLoaded['createMeasurements'] === undefined 
+		    		&& $rootScope.stateSuccessfullyLoaded['editMeasurements'] === undefined){
 				$scope.loadMeasurementsTabInBackground();
 			}	
 


### PR DESCRIPTION
Improved the condition for the preload of measurement table using the $rootScope.stateSuccessfullyLoaded[] variable.

Ready for Review.