### PR TITLE
Mock fieldbookService.getValue

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -172,4 +172,8 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 		this.fieldbookMiddlewareService = fieldbookMiddlewareService;
 	}
 
+	protected void setFieldbookService(com.efficio.fieldbook.service.api.FieldbookService fieldbookService) {
+		this.fieldbookService = fieldbookService;
+	}
+
 }


### PR DESCRIPTION
Please review

After merging newOm
https://github.com/IntegratedBreedingPlatform/DBScripts/pull/65
maize crop does not have PLANT_HEIGHT_MEAN variable any more
Mocking getValue avoid having to reach the database for the variable

Issue: BMS-4113