### PR TITLE
Bms 4091 fix import crosses suffix bug

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/service/impl/CrossingServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/service/impl/CrossingServiceImpl.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.annotation.Resource;
 
@@ -30,7 +28,6 @@ import org.generationcp.commons.settings.CrossSetting;
 import org.generationcp.commons.spring.util.ContextUtil;
 import org.generationcp.commons.util.CrossingUtil;
 import org.generationcp.commons.util.DateUtil;
-import org.generationcp.commons.util.ExpressionHelper;
 import org.generationcp.commons.util.StringUtil;
 import org.generationcp.middleware.domain.etl.Workbook;
 import org.generationcp.middleware.exceptions.MiddlewareQueryException;
@@ -537,9 +534,10 @@ public class CrossingServiceImpl implements CrossingService {
 		return nextNumberInSequence;
 
 	}
-	
+
 	/*
-	 * This method is only used for Specify Name Scenario in import crosses and design crosses
+	 * This method is only used for Specify Name Scenario in import crosses and
+	 * design crosses
 	 */
 	protected String buildDesignationNameInSequence(final ImportedCrosses importedCrosses, final Integer number,
 			final CrossSetting setting) {

--- a/src/test/java/com/efficio/fieldbook/web/common/service/impl/CrossingServiceImplTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/service/impl/CrossingServiceImplTest.java
@@ -10,7 +10,6 @@ import org.generationcp.commons.parsing.pojo.ImportedCrossesList;
 import org.generationcp.commons.ruleengine.ProcessCodeOrderedRule;
 import org.generationcp.commons.ruleengine.ProcessCodeRuleFactory;
 import org.generationcp.commons.ruleengine.RuleException;
-import org.generationcp.commons.ruleengine.RuleExecutionContext;
 import org.generationcp.commons.service.impl.SeedSourceGenerator;
 import org.generationcp.commons.settings.AdditionalDetailsSetting;
 import org.generationcp.commons.settings.BreedingMethodSetting;
@@ -378,7 +377,7 @@ public class CrossingServiceImplTest {
 	@Test
 	public void testBuildDesignationNameInSequenceSuffixIsAvailable() throws RuleException {
 		final String specifiedSuffix = "AAA";
-		
+
 		final CrossSetting crossSetting = new CrossSetting();
 		final CrossNameSetting crossNameSetting = new CrossNameSetting();
 		crossNameSetting.setSuffix(specifiedSuffix);


### PR DESCRIPTION
Removed logic that gets the suffix of the breeding method when the user did not specify any suffix for manual name generation.