### PR TITLE
BMS-4232 remove library itextpdf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,32 @@
 			<groupId>org.generationcp</groupId>
 			<artifactId>middleware</artifactId>
 			<version>${ibpcommons.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-beans</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-aop</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-context</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.itextpdf</groupId>
+					<artifactId>itext-pdfa</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.itextpdf</groupId>
+					<artifactId>itextpdf</artifactId>
+				</exclusion>
+			</exclusions>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -516,7 +542,6 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.1.1</version>
 				<configuration>
-					<packagingExcludes>WEB-INF/lib/itextpdf*.jar,itext-pdfa*.jar</packagingExcludes>
 					<archive>
 						<manifest>
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
Hi @clarysabel and @nahuelsoldevilla-droptek 

This PR contains the exclusion of the itextpdf and itext-pdfa.

Include #[**69**](https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/69) BMSAPI
Include #[**240**](https://github.com/IntegratedBreedingPlatform/BreedingManager/pull/240) BreedingManager
Include #[**141**](https://github.com/IntegratedBreedingPlatform/Commons/pull/141) Commons
Include #[**17**](https://github.com/IntegratedBreedingPlatform/GDMS/pull/17) GDMS
Include #[**35**](https://github.com/IntegratedBreedingPlatform/Migrator3to4/pull/35) Migrator3to4
Include #[**143**](https://github.com/IntegratedBreedingPlatform/Workbench/pull/143) Workbench

Please review.
Regards, Diego