### PR TITLE
BMS-4232 remove library itextpdf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,22 +236,6 @@
 			<version>${ibpcommons.version}</version>
 			<exclusions>
 				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-beans</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-aop</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-context</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>com.itextpdf</groupId>
 					<artifactId>itext-pdfa</artifactId>
 				</exclusion>


### PR DESCRIPTION
Hi @clarysabel and @nahuelsoldevilla-droptek 

This PR contains the exclusion of the itextpdf and itext-pdfa.

Include #[**70**](https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/70) BMSAPI
Include #[**241**](https://github.com/IntegratedBreedingPlatform/BreedingManager/pull/241) BreedingManager
Include #[**141**](https://github.com/IntegratedBreedingPlatform/Commons/pull/141) Commons
Include #[**17**](https://github.com/IntegratedBreedingPlatform/GDMS/pull/17) GDMS
Include #[**35**](https://github.com/IntegratedBreedingPlatform/Migrator3to4/pull/35) Migrator3to4
Include #[**144**](https://github.com/IntegratedBreedingPlatform/Workbench/pull/144) Workbench

Please review.
Regards, Diego