### PR TITLE
BMS-4254-Removed onChange listeners for nursery datepickers 

### DIFF
--- a/src/main/webapp/WEB-INF/pages/Common/saveGermplasmList.html
+++ b/src/main/webapp/WEB-INF/pages/Common/saveGermplasmList.html
@@ -81,15 +81,7 @@
 
 	if ($('#saveListForm .date-input').length > 0) {
 		$('#saveListForm .date-input').each(function() {
-			$(this).datepicker({'format': 'yyyy-mm-dd'}).on('change', function() {
-				var curDate = $(this).val();
-				try {
-					var r = $.datepicker.parseDate('yy-mm-dd', curDate);
-					$(this).datepicker('setDate', r);
-				} catch (e) {
-					$(this).datepicker('setDate', new Date());
-				}
-			}).on('changeDate', function() {
+			$(this).datepicker({'format': 'yyyy-mm-dd'}).on('changeDate', function() {
 				$(this).datepicker('hide');
 
 			}).on('show', function() {

--- a/src/main/webapp/WEB-INF/pages/Common/updateExperimentModal.html
+++ b/src/main/webapp/WEB-INF/pages/Common/updateExperimentModal.html
@@ -81,14 +81,6 @@ $( document ).ready(function() {
 				'format': 'yyyy-mm-dd'
 			}).on('changeDate', function() {
 				$(this).datepicker('hide');
-			}).on('change', function() {
-				var curDate = $(this).val();
-				try {
-					var r = $.datepicker.parseDate('yy-mm-dd', curDate);
-					$(this).datepicker('setDate', r);
-				} catch (e) {
-					$(this).datepicker('setDate', new Date());
-				}
 			});
 		});
 	}

--- a/src/main/webapp/WEB-INF/pages/NurseryManager/inlineInputMeasurement.html
+++ b/src/main/webapp/WEB-INF/pages/NurseryManager/inlineInputMeasurement.html
@@ -119,14 +119,6 @@ $(document).ready(function() {
 			}).on('changeDate', function() {
 				$(this).datepicker('hide');
 				$('body').data('last-td-time-clicked', new Date().getTime());
-			}).on('change', function() {
-				var curDate = $(this).val();
-				try {
-					var r = $.datepicker.parseDate('yy-mm-dd', curDate);
-					$(this).datepicker('setDate', r);
-				} catch (e) {
-					$(this).datepicker('setDate', new Date());
-				}
 			});
 		});
 	}

--- a/src/main/webapp/WEB-INF/static/js/nurseryManager.js
+++ b/src/main/webapp/WEB-INF/static/js/nurseryManager.js
@@ -1424,16 +1424,6 @@ function initializeDateAndSliderInputs() {
 				'format': 'yyyy-mm-dd'
 			}).on('changeDate', function(ev) {
 				$(this).datepicker('hide');
-			}).on('change', function(e) {
-				var curDate = $(this).val();
-				try {
-					var r = $.datepicker.parseDate('yy-mm-dd', curDate);
-					$(this).datepicker('setDate', r);
-				} catch (e) {
-					if (curDate !== '') {
-						$(this).datepicker('setDate', new Date());
-					}
-				}
 			});
 		});
 	}


### PR DESCRIPTION
Resetting the selected value sometimes causes the date to be one day behind when the timezone is ahead of UTC (UTC+).