### PR TITLE
BMS 3901 Disable automatic column width calculation in Preview Crosses Table. …

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/fbk-data-table/fieldbook-datatable.js
+++ b/src/main/webapp/WEB-INF/static/js/fbk-data-table/fieldbook-datatable.js
@@ -262,7 +262,7 @@ BMS.Fieldbook.PreviewCrossesDataTable = (function($) {
 				scrollCollapse: true,
 				columnDefs: columnsDef,
 				lengthMenu: [[50, 75, 100, -1], [50, 75, 100, 'All']],
-				bAutoWidth: true,
+				bAutoWidth: false,
 				iDisplayLength: 100,
 				retrieve: true,
 				fnRowCallback: function(nRow, aData, iDisplayIndex, iDisplayIndexFull) {


### PR DESCRIPTION
…This will fix the truncated column (SeedSource) in the table.

BMS-3901