### PR TITLE
BMS-4347 Manage Samples

### DIFF
--- a/src/main/webapp/WEB-INF/pages/TrialManager/templates/managerSampleListModal.html
+++ b/src/main/webapp/WEB-INF/pages/TrialManager/templates/managerSampleListModal.html
@@ -94,7 +94,7 @@
 				$('#sampleSelectUser').select2();
 
 				$('#sampleSelectVariable').focus();
-				$('#report-type-section').select2();
+				$('#sampleSelectVariable').select2();
 
 				$('#sampleSelectSamplingDate').datepicker({dateFormat: "yyyy-mm-dd"}).val('');
 			});


### PR DESCRIPTION
Hi @clarysabel and @nahuelsoldevilla-droptek 

This PR contains the fix to reset the selection variable by default in managerSampleListModal.html
Issue: BMS-4347

Please review.
Regards, Diego