### PR TITLE
BMS-4766 PI_NAME in View Sammary

### DIFF
--- a/src/main/java/com/efficio/fieldbook/service/FieldbookServiceImpl.java
+++ b/src/main/java/com/efficio/fieldbook/service/FieldbookServiceImpl.java
@@ -562,6 +562,8 @@ public class FieldbookServiceImpl implements FieldbookService {
 			return this.getBreedingMethodByName(valueOrId);
 		} else if (DataType.LOCATION.equals(variable.getScale().getDataType())) {
 			return this.getLocationById(valueId.intValue());
+		} else if (DataType.PERSON.equals(variable.getScale().getDataType())) {
+			return this.getPersonByUserId(valueId.intValue());
 		} else if (isCategorical) {
 			final Term term = this.ontologyService.getTermById(valueId.intValue());
 			if (term != null) {


### PR DESCRIPTION
Hi @clarysabel and @nahuel-soldevilla 
I Changed the cvterm_id on the property, because it was hiding the PI_NAME instead of the PI_ID.

Please, review
Regards, Diego