### PR TITLE
Set focused node before opening/choosing folder. Ordinarily, it will …

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/studyTree.js
+++ b/src/main/webapp/WEB-INF/static/js/studyTree.js
@@ -106,6 +106,7 @@ function chooseStudyNode(fromEnterKey, doOpenStudy) {
 
 function chooseStudy() {
 	'use strict';
+	focusNode = $('#studyTree').dynatree('getTree').getActiveNode();
 	chooseStudyNode(false, false);
 }
 


### PR DESCRIPTION
…be set by clicking on the node but this fixes/covers when a new folder node was added to tree and it is the active node.

IBP-2267