### PR TITLE
IBP-3320 Fix Select Variable Callback

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/design-import/design-import-main.js
+++ b/src/main/webapp/WEB-INF/static/js/design-import/design-import-main.js
@@ -178,8 +178,8 @@
 		};
 	}]);
 
-	app.directive('designMapVariableSelection', ['VARIABLE_SELECTION_MODAL_SELECTOR', 'DesignOntologyService', 'Messages',
-		function(VARIABLE_SELECTION_MODAL_SELECTOR, DesignOntologyService, Messages) {
+	app.directive('designMapVariableSelection', ['VARIABLE_SELECTION_MODAL_SELECTOR', 'VARIABLE_SELECTED_EVENT_TYPE', 'DesignOntologyService', 'Messages',
+		function(VARIABLE_SELECTION_MODAL_SELECTOR, VARIABLE_SELECTED_EVENT_TYPE, DesignOntologyService, Messages) {
 			return {
 				restrict: 'A',
 				scope: {
@@ -229,6 +229,9 @@
 								noAlias: true
 							}
 						};
+
+						$(VARIABLE_SELECTION_MODAL_SELECTOR).off(VARIABLE_SELECTED_EVENT_TYPE);
+						$(VARIABLE_SELECTION_MODAL_SELECTOR).on(VARIABLE_SELECTED_EVENT_TYPE, scope.processData);
 
 						$designMapModal.one('hidden.bs.modal', function() {
 							setTimeout(function() {

--- a/src/main/webapp/WEB-INF/static/js/importObservations/variateGroupImporter.js
+++ b/src/main/webapp/WEB-INF/static/js/importObservations/variateGroupImporter.js
@@ -169,8 +169,8 @@
 		};
 	}]);
 
-	app.directive('importMapVariableSelection', ['VARIABLE_SELECTION_MODAL_SELECTOR', 'DesignOntologyService', 'Messages',
-		function (VARIABLE_SELECTION_MODAL_SELECTOR, DesignOntologyService, Messages) {
+	app.directive('importMapVariableSelection', ['VARIABLE_SELECTION_MODAL_SELECTOR', 'VARIABLE_SELECTED_EVENT_TYPE', 'DesignOntologyService', 'Messages',
+		function (VARIABLE_SELECTION_MODAL_SELECTOR, VARIABLE_SELECTED_EVENT_TYPE, DesignOntologyService, Messages) {
 			return {
 				restrict: 'A',
 				scope: {
@@ -220,6 +220,9 @@
 								noAlias: true
 							}
 						};
+
+						$(VARIABLE_SELECTION_MODAL_SELECTOR).off(VARIABLE_SELECTED_EVENT_TYPE);
+						$(VARIABLE_SELECTION_MODAL_SELECTOR).on(VARIABLE_SELECTED_EVENT_TYPE, scope.processData);
 
 						$importMapModal.one('hidden.bs.modal', function () {
 							setTimeout(function () {


### PR DESCRIPTION
Hi @nahuel-soldevilla , @clarysabel,

  Kindly review this fix for making sure the sub-observations Add Traits/Add Selections callback is not triggerred when performing mapping in Import Design and Add Traits screen.

  Disclaimer: There might be a better, more centralized way to solve the issue but I went with the least risky solution (no refactoring involved) for now.