### PR TITLE
IBP-3681 Upgrade to yarn v1.21.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<spring.security.version>3.2.5.RELEASE</spring.security.version>
 		<envConfig>${user.name}</envConfig>
 		<node.version>v8.11.3</node.version>
-		<yarn.version>v1.3.2</yarn.version>
+		<yarn.version>v1.21.1</yarn.version>
 		<frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
 	</properties>
 


### PR DESCRIPTION
Use a recent version of yarn, to be able to use npm semver format in git
dependencies (Available since 1.4).

