### PR TITLE
IBP-2753-ImportKSUDateFormat

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/importStudy.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/importStudy.js
@@ -263,7 +263,7 @@
 						reader.onload = function (e) {
 							/* read workbook */
 							var bstr = e.target.result;
-							var wb = XLSX.read(bstr, {type: 'binary'});
+							var wb = XLSX.read(bstr, {type: 'binary', raw: true});
 
 							/* grab first sheet */
 							var wsname = wb.SheetNames[0];


### PR DESCRIPTION
Set xlsx.read to raw: true to prevent method to parse into date. 