### PR TITLE
IBP-4132-AllowNegativeValuesInNText

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/angular/fieldbook-utils.js
+++ b/src/main/webapp/WEB-INF/static/js/angular/fieldbook-utils.js
@@ -255,7 +255,7 @@
 					}
 
 					ngModelCtrl.$parsers.push(function(val) {
-						var clean = val.replace(/[^0-9.]+/g, '');
+						var clean = val.replace(/[^-?0-9.]+/g, '');
 						if (val !== clean) {
 							ngModelCtrl.$setViewValue(clean);
 							ngModelCtrl.$render();


### PR DESCRIPTION
Modified regex to accept negative character 
Existing issue: user can enter more than 1 character of negative and decimal, but upon saving only valid characters are saved. 
