### PR TITLE
IBP-4476-PRepDesignNonReplicatedEntries

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/AbstractBaseFieldbookController.java
+++ b/src/main/java/com/efficio/fieldbook/web/AbstractBaseFieldbookController.java
@@ -197,6 +197,17 @@ public abstract class AbstractBaseFieldbookController {
 		return checkEntryTypeIds;
 	}
 
+  protected List<String> getAllNonReplicatedEntryTypeIds() {
+	final List<ValueReference> entryTypes = this.fieldbookService.getAllPossibleValues(TermId.ENTRY_TYPE.getId(), true);
+	final List<String> nonReplicatedEntryTypeIds = new ArrayList<>();
+	for (final ValueReference entryType : entryTypes) {
+	  if (SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId() == entryType.getId()) {
+		nonReplicatedEntryTypeIds.add(entryType.getId().toString());
+	  }
+	}
+	return nonReplicatedEntryTypeIds;
+  }
+
 	public void setContextUtil(final ContextUtil contextUtil) {
 		this.contextUtil = contextUtil;
 	}

--- a/src/main/java/com/efficio/fieldbook/web/AbstractBaseFieldbookController.java
+++ b/src/main/java/com/efficio/fieldbook/web/AbstractBaseFieldbookController.java
@@ -197,17 +197,6 @@ public abstract class AbstractBaseFieldbookController {
 		return checkEntryTypeIds;
 	}
 
-  protected List<String> getAllNonReplicatedEntryTypeIds() {
-	final List<ValueReference> entryTypes = this.fieldbookService.getAllPossibleValues(TermId.ENTRY_TYPE.getId(), true);
-	final List<String> nonReplicatedEntryTypeIds = new ArrayList<>();
-	for (final ValueReference entryType : entryTypes) {
-	  if (SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId() == entryType.getId()) {
-		nonReplicatedEntryTypeIds.add(entryType.getId().toString());
-	  }
-	}
-	return nonReplicatedEntryTypeIds;
-  }
-
 	public void setContextUtil(final ContextUtil contextUtil) {
 		this.contextUtil = contextUtil;
 	}

--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -288,13 +288,13 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 	}
 
 	private long countNumberOfChecks(final StudyDetails studyDetails, final Optional<Long> nonReplicatedEntriesCount) {
-	  final long countCheckEntries = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
+	  final long checkEntriesCount = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
 
 	  if (TermId.P_REP.getId() == this.getExperimentalDesignValue(studyDetails) && nonReplicatedEntriesCount.isPresent()) {
-		return countCheckEntries - nonReplicatedEntriesCount.get();
+		return checkEntriesCount - nonReplicatedEntriesCount.get();
 	  }
 
-	  return countCheckEntries;
+	  return checkEntriesCount;
 	}
 
 	private int getExperimentalDesignValue(final StudyDetails studyDetails) {

--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -127,8 +127,12 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 			this.addErrorMessageToResult(details, e, id);
 		}
 
+		final long countNonReplicatedEntries = this.studyEntryService.countStudyGermplasmByEntryTypeIds(id, this.getAllNonReplicatedEntryTypeIds());
+		final long numberOfChecks = this.countNumberOfChecks(details, countNonReplicatedEntries);
+
 		model.addAttribute("trialDetails", details);
-		model.addAttribute("numberOfChecks", this.studyEntryService.countStudyGermplasmByEntryTypeIds(id, getAllCheckEntryTypeIds()));
+		model.addAttribute("numberOfChecks", numberOfChecks);
+		model.addAttribute("numberOfNonReplicatedEntries", countNonReplicatedEntries);
 		this.setIsSuperAdminAttribute(model);
 		return this.showAjaxPage(model, this.getContentName());
 	}
@@ -276,5 +280,24 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 
 	public void setStudyEntryService(final StudyEntryService studyEntryService) {
 		this.studyEntryService = studyEntryService;
+	}
+
+	private long countNumberOfChecks(final StudyDetails studyDetails, final long countNonReplicatedEntries) {
+	  final long countCheckEntries = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
+
+	  final int experimentalDesignValue = this.getExperimentalDesignValue(studyDetails);
+	  if (TermId.P_REP.getId() == experimentalDesignValue) {
+		return countCheckEntries - countNonReplicatedEntries;
+	  }
+
+	  return countCheckEntries;
+	}
+
+	private int getExperimentalDesignValue(final StudyDetails studyDetails) {
+	  if (studyDetails.getExperimentalDesignDetails() != null && studyDetails.getExperimentalDesignDetails().getExperimentalDesign() != null) {
+	    return studyDetails.getExperimentalDesignDetails().getExperimentalDesign().getValue() == null ? 0 :
+				Integer.parseInt(studyDetails.getExperimentalDesignDetails().getExperimentalDesign().getValue());
+	  }
+	  return 0;
 	}
 }

--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -136,7 +136,7 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 		model.addAttribute("trialDetails", details);
 		model.addAttribute("numberOfChecks", numberOfChecks);
 		if (nonReplicatedEntriesCount.isPresent()) {
-			model.addAttribute("numberOfNonReplicatedEntries", nonReplicatedEntriesCount.get());
+			model.addAttribute("nonReplicatedEntriesCount", nonReplicatedEntriesCount.get());
 		}
 		this.setIsSuperAdminAttribute(model);
 		return this.showAjaxPage(model, this.getContentName());
@@ -287,11 +287,11 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 		this.studyEntryService = studyEntryService;
 	}
 
-	private long countNumberOfChecks(final StudyDetails studyDetails, final Optional<Long> countNonReplicatedEntries) {
+	private long countNumberOfChecks(final StudyDetails studyDetails, final Optional<Long> nonReplicatedEntriesCount) {
 	  final long countCheckEntries = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
 
-	  if (TermId.P_REP.getId() == this.getExperimentalDesignValue(studyDetails) && countNonReplicatedEntries.isPresent()) {
-		return countCheckEntries - countNonReplicatedEntries.get();
+	  if (TermId.P_REP.getId() == this.getExperimentalDesignValue(studyDetails) && nonReplicatedEntriesCount.isPresent()) {
+		return countCheckEntries - nonReplicatedEntriesCount.get();
 	  }
 
 	  return countCheckEntries;

--- a/src/main/resources/Messages.properties
+++ b/src/main/resources/Messages.properties
@@ -296,6 +296,7 @@ study.experimental.design.number.of.environments=Number of environments:
 study.experimental.design.number.of.treatments=Number of treatments:
 study.experimental.design.number.of.blocks=Number of blocks per replication :
 study.experimental.design.selected.design=Design based on design template:
+study.experimental.design.number.of.non.replicated.entries=Number of Non Replicated entries:
 
 no.study.dataset.found=The Environment Dataset required for this Study is missing from the database, or possibly corrupt. Please contact support for assistance.
 study.error.parser.format.date.basic.details=Invalid format date in basic details of the study
@@ -1063,6 +1064,7 @@ review.study.number.of.check.entries=Number of Check entries:
 review.study.total.number.of.plots=Total number of plots:
 review.study.number.of.entries.per.block=Number of entries per block:
 review.study.percentage.of.replication=% of test entries to replicate:
+review.study.number.of.non.replicated.entries=Number of Non Replicated entries:
 
 error.review.study.summary.format.invalid=This {0} is in a format that cannot be opened in the {1} Manager. Please use the Study Browser if you wish to see the details of this {0}.
 

--- a/src/main/webapp/WEB-INF/pages/TrialManager/reviewTrialDetails.html
+++ b/src/main/webapp/WEB-INF/pages/TrialManager/reviewTrialDetails.html
@@ -475,6 +475,12 @@
                                 <span id="review-number-of-check-entries" th:text="${numberOfChecks}"></span>
                             </td>
                         </tr>
+                        <tr th:if="*{experimentalDesignDetails.experimentalDesign.value == '10164'}">
+                            <td>
+                                <strong th:text="#{review.study.number.of.non.replicated.entries}"></strong>
+                                <span id="review-number-of-non-replicated-entries" th:text="${numberOfNonReplicatedEntries}"></span>
+                            </td>
+                        </tr>
                         <tr th:if="*{experimentalDesignDetails.experimentalDesign.value != '10164'}" id="row-review-number-of-blocks">
                             <td>
                                 <strong th:text="#{review.study.number.of.blocks}"></strong>

--- a/src/main/webapp/WEB-INF/pages/TrialManager/reviewTrialDetails.html
+++ b/src/main/webapp/WEB-INF/pages/TrialManager/reviewTrialDetails.html
@@ -478,7 +478,7 @@
                         <tr th:if="*{experimentalDesignDetails.experimentalDesign.value == '10164'}">
                             <td>
                                 <strong th:text="#{review.study.number.of.non.replicated.entries}"></strong>
-                                <span id="review-number-of-non-replicated-entries" th:text="${numberOfNonReplicatedEntries}"></span>
+                                <span id="review-number-of-non-replicated-entries" th:text="${nonReplicatedEntriesCount}"></span>
                             </td>
                         </tr>
                         <tr th:if="*{experimentalDesignDetails.experimentalDesign.value != '10164'}" id="row-review-number-of-blocks">

--- a/src/main/webapp/WEB-INF/pages/TrialManager/templates/experimentalDesignBVDesign.html
+++ b/src/main/webapp/WEB-INF/pages/TrialManager/templates/experimentalDesignBVDesign.html
@@ -49,6 +49,10 @@
 				<b>Number of Check entries:</b>
 				<span>{{germplasmTotalCheckEntriesCount}}</span>
 			</div>
+			<div class="add-bottom-padding" ng-show="currentDesignType.id == 6">
+				<b th:text="#{study.experimental.design.number.of.non.replicated.entries}"></b>
+				<span>{{germplasmTotalNonReplicatedEntriesCounts}}</span>
+			</div>
 			<div class="add-bottom-padding" ng-show="showOnlyIfNumberOfBlocksIsSpecified()">
 				<b>Number of Test entries per block:</b>
 				<span ng-show="germplasmNumberOfTestEntriesPerBlock % 1 === 0">{{germplasmNumberOfTestEntriesPerBlock}}</span>

--- a/src/main/webapp/WEB-INF/static/js/trialmanager/experimentalDesign.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/experimentalDesign.js
@@ -713,8 +713,9 @@
 
 					$scope.refreshDesignDetailsForPRepDesign = function() {
 						studyEntryService.getStudyEntriesMetadata().then(function (metadata) {
-							$scope.germplasmTotalCheckEntriesCount = metadata.nonTestEntriesCount;
-							$scope.germplasmTotalTestEntriesCount = $scope.totalGermplasmEntryListCount - $scope.germplasmTotalCheckEntriesCount;
+							$scope.germplasmTotalNonReplicatedEntriesCounts = metadata.nonReplicatedEntriesCount;
+							$scope.germplasmTotalCheckEntriesCount = metadata.nonTestEntriesCount - $scope.germplasmTotalNonReplicatedEntriesCounts;
+							$scope.germplasmTotalTestEntriesCount = $scope.totalGermplasmEntryListCount - $scope.germplasmTotalCheckEntriesCount - $scope.germplasmTotalNonReplicatedEntriesCounts;
 							var noOfTestEntriesToReplicate = Math.round($scope.germplasmTotalTestEntriesCount * ($scope.data.replicationPercentage / 100));
 							$scope.germplasmTotalNumberOfPlots = ($scope.germplasmTotalTestEntriesCount - noOfTestEntriesToReplicate) +
 								(noOfTestEntriesToReplicate * $scope.data.replicationsCount) +

--- a/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
@@ -48,6 +48,7 @@ import org.springframework.ui.Model;
 
 import javax.annotation.Resource;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -144,12 +145,11 @@ public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTes
 		final Model model = new ExtendedModelMap();
 		final List<ValueReference> allEntries = this.getAllEntries(5, 3, 5);
 		final List<String> checksEntries = this.getAllCheckEntryTypeIds(allEntries);
-		final List<String> nonReplicatedEntries = this.getAllNonReplicatedEntryTypeIds(allEntries);
 
 		Mockito.when(this.fieldbookService.getAllPossibleValues(TermId.ENTRY_TYPE.getId(), true)).thenReturn(allEntries);
 		Mockito.doReturn(5L).when(this.studyEntryService).countStudyGermplasmByEntryTypeIds(id, checksEntries);
 		Mockito.doReturn(3L).when(this.studyEntryService).countStudyGermplasmByEntryTypeIds(id,
-				nonReplicatedEntries);
+				Collections.singletonList(String.valueOf(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId())));
 		this.reviewStudyDetailsController.show(id, form, model);
 
 		final StudyDetails details = (StudyDetails) model.asMap().get("trialDetails");
@@ -298,16 +298,6 @@ public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTes
 		final ArrayList<String> ids = new ArrayList<>();
 		for (final ValueReference valueReference : valueReferences) {
 			if (SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId() != valueReference.getId()) {
-				ids.add(String.valueOf(valueReference.getId()));
-			}
-		}
-		return ids;
-	}
-
-	private List<String> getAllNonReplicatedEntryTypeIds(final List<ValueReference> valueReferences) {
-		final ArrayList<String> ids = new ArrayList<>();
-		for (final ValueReference valueReference : valueReferences) {
-			if (SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId() == valueReference.getId()) {
 				ids.add(String.valueOf(valueReference.getId()));
 			}
 		}

--- a/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
@@ -258,7 +258,7 @@ public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTes
 		return term;
 	}
 
-	private List<ValueReference> getAllEntries(final int checksSize, final int nonReplicatedSize, final int testSize) {
+	private List<ValueReference> getAllEntries(final int checksSize, final int nonReplicatedEntriesCount, final int testSize) {
 		final ArrayList<ValueReference> references = new ArrayList<>();
 
 		for (int i=0; i<checksSize; i++) {
@@ -271,7 +271,7 @@ public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTes
 			references.add(reference);
 		}
 
-		for (int i=0; i<nonReplicatedSize; i++) {
+		for (int i=0; i<nonReplicatedEntriesCount; i++) {
 			ValueReference reference = new ValueReference();
 			reference.setId(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId());
 			reference.setName(RandomStringUtils.randomAlphanumeric(10));

--- a/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsControllerTest.java
@@ -51,8 +51,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
-
 
 public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTest {
 
@@ -240,10 +238,13 @@ public class ReviewStudyDetailsControllerTest extends AbstractBaseIntegrationTes
 
 	@Test
 	public void testShowStudyPrepDesignSummary() {
-
-
 		final Workbook wb = this.workbook;
-		wb.setExperimentalDesignVariables(Collections.singletonList(WorkbookTestDataInitializer.createExperimentalPrepVariable()));
+		final MeasurementVariable prepDesign = WorkbookTestDataInitializer.createMeasurementVariable(WorkbookTestDataInitializer.EXPT_DESIGN_ID, "DESIGN",
+				"EXPERIMENTAL DESIGN", WorkbookTestDataInitializer.TYPE, WorkbookTestDataInitializer.ASSIGNED,
+				WorkbookTestDataInitializer.EXPERIMENT_DESIGN, WorkbookTestDataInitializer.CHAR,
+				String.valueOf(TermId.P_REP.getId()), WorkbookTestDataInitializer.TRIAL,
+				TermId.CHARACTER_VARIABLE.getId(), PhenotypicType.TRIAL_ENVIRONMENT, false);
+		wb.setExperimentalDesignVariables(Collections.singletonList(prepDesign));
 		Mockito.doReturn(wb).when(this.fieldbookMWService).getStudyVariableSettings(ArgumentMatchers.anyInt());
 		this.mockStandardVariables(this.workbook.getAllVariables(), this.fieldbookMWService, this.fieldbookService);
 


### PR DESCRIPTION
Display nonReplicatedEntries in experimental tab for both open study and view summary 
In ReviewStudyDetailsController (Summary), nonReplicated entries will be deducted from checkEntries if PrepDesign 
Unit test