### PR TITLE
IBP-4515-PrepDesignRemoveFilterByRepNo

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -291,7 +291,7 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 	private long countNumberOfChecks(final StudyDetails studyDetails, final Optional<Long> nonReplicatedEntriesCount) {
 	  final long checkEntriesCount = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
 
-	  if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignDetails(studyDetails.getExperimentalDesignDetails()) && nonReplicatedEntriesCount.isPresent()) {
+	  if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(studyDetails.getExperimentalDesignDetails()) && nonReplicatedEntriesCount.isPresent()) {
 		return checkEntriesCount - nonReplicatedEntriesCount.get();
 	  }
 
@@ -299,7 +299,7 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 	}
 
 	private Optional<Long> getNonReplicatedEntriesCount(final StudyDetails studyDetails) {
-		if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignDetails(studyDetails.getExperimentalDesignDetails())) {
+		if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(studyDetails.getExperimentalDesignDetails())) {
 			return Optional.of(this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(),
 					Collections.singletonList(String.valueOf(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId()))));
 		}

--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ReviewStudyDetailsController.java
@@ -18,6 +18,7 @@ import com.efficio.fieldbook.web.common.bean.SettingDetail;
 import com.efficio.fieldbook.web.common.bean.StudyDetails;
 import com.efficio.fieldbook.web.common.bean.UserSelection;
 import com.efficio.fieldbook.web.trial.form.CreateTrialForm;
+import com.efficio.fieldbook.web.util.ExpDesignUtil;
 import com.efficio.fieldbook.web.util.SettingsUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -290,23 +291,15 @@ public class ReviewStudyDetailsController extends AbstractBaseFieldbookControlle
 	private long countNumberOfChecks(final StudyDetails studyDetails, final Optional<Long> nonReplicatedEntriesCount) {
 	  final long checkEntriesCount = this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(), this.getAllCheckEntryTypeIds());
 
-	  if (TermId.P_REP.getId() == this.getExperimentalDesignValue(studyDetails) && nonReplicatedEntriesCount.isPresent()) {
+	  if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignDetails(studyDetails.getExperimentalDesignDetails()) && nonReplicatedEntriesCount.isPresent()) {
 		return checkEntriesCount - nonReplicatedEntriesCount.get();
 	  }
 
 	  return checkEntriesCount;
 	}
 
-	private int getExperimentalDesignValue(final StudyDetails studyDetails) {
-	  if (studyDetails.getExperimentalDesignDetails() != null && studyDetails.getExperimentalDesignDetails().getExperimentalDesign() != null) {
-	    return studyDetails.getExperimentalDesignDetails().getExperimentalDesign().getValue() == null ? 0 :
-				Integer.parseInt(studyDetails.getExperimentalDesignDetails().getExperimentalDesign().getValue());
-	  }
-	  return 0;
-	}
-
 	private Optional<Long> getNonReplicatedEntriesCount(final StudyDetails studyDetails) {
-		if (TermId.P_REP.getId() == this.getExperimentalDesignValue(studyDetails)) {
+		if (TermId.P_REP.getId() == ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignDetails(studyDetails.getExperimentalDesignDetails())) {
 			return Optional.of(this.studyEntryService.countStudyGermplasmByEntryTypeIds(studyDetails.getId(),
 					Collections.singletonList(String.valueOf(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId()))));
 		}

--- a/src/main/java/com/efficio/fieldbook/web/trial/controller/AdvancingController.java
+++ b/src/main/java/com/efficio/fieldbook/web/trial/controller/AdvancingController.java
@@ -228,7 +228,7 @@ public class AdvancingController extends AbstractBaseFieldbookController {
 
     private Optional<List<String>> getOptionalReplicationChoices(final String noOfReplications, final ExperimentalDesignVariable experimentalDesignVariable){
 
-		if (TermId.P_REP.getId() != ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignDetails(experimentalDesignVariable)) {
+		if (TermId.P_REP.getId() != ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(experimentalDesignVariable)) {
 			final List<String> replicationChoices = new ArrayList<>();
 			if(noOfReplications != null){
 				final int replicationCount = Integer.parseInt(noOfReplications);

--- a/src/main/java/com/efficio/fieldbook/web/util/ExpDesignUtil.java
+++ b/src/main/java/com/efficio/fieldbook/web/util/ExpDesignUtil.java
@@ -2,6 +2,7 @@ package com.efficio.fieldbook.web.util;
 
 import com.efficio.fieldbook.service.api.FieldbookService;
 import org.generationcp.middleware.domain.dms.StandardVariable;
+import org.generationcp.middleware.domain.etl.ExperimentalDesignVariable;
 import org.generationcp.middleware.domain.etl.MeasurementVariable;
 import org.generationcp.middleware.exceptions.MiddlewareException;
 import org.generationcp.middleware.manager.Operation;
@@ -39,6 +40,14 @@ public class ExpDesignUtil {
 			ExpDesignUtil.LOG.error(e.getMessage(), e);
 		}
 		return mvar;
+	}
+
+	public static int getExperimentalDesignValueFromExperimentalDesignDetails(final ExperimentalDesignVariable experimentalDesignVariable) {
+		if (experimentalDesignVariable != null && experimentalDesignVariable.getExperimentalDesign() != null) {
+			return experimentalDesignVariable.getExperimentalDesign().getValue() == null ? 0 :
+					Integer.parseInt(experimentalDesignVariable.getExperimentalDesign().getValue());
+		}
+		return 0;
 	}
 
 }

--- a/src/main/java/com/efficio/fieldbook/web/util/ExpDesignUtil.java
+++ b/src/main/java/com/efficio/fieldbook/web/util/ExpDesignUtil.java
@@ -42,7 +42,7 @@ public class ExpDesignUtil {
 		return mvar;
 	}
 
-	public static int getExperimentalDesignValueFromExperimentalDesignDetails(final ExperimentalDesignVariable experimentalDesignVariable) {
+	public static int getExperimentalDesignValueFromExperimentalDesignVariable(final ExperimentalDesignVariable experimentalDesignVariable) {
 		if (experimentalDesignVariable != null && experimentalDesignVariable.getExperimentalDesign() != null) {
 			return experimentalDesignVariable.getExperimentalDesign().getValue() == null ? 0 :
 					Integer.parseInt(experimentalDesignVariable.getExperimentalDesign().getValue());

--- a/src/test/java/com/efficio/fieldbook/web/trial/controller/AdvancingControllerTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/trial/controller/AdvancingControllerTest.java
@@ -198,7 +198,7 @@ public class AdvancingControllerTest {
 		Assert.assertNotNull("should have generated unique id", output.get("uniqueId"));
 
 
-		Mockito.verify(this.fieldbookMiddlewareService, Mockito.times(1)).getMethodById(Integer.valueOf(form.getAdvanceBreedingMethodId()));
+		Mockito.verify(this.fieldbookMiddlewareService, Mockito.times(1)).getMethodById(Integer.parseInt(form.getAdvanceBreedingMethodId()));
 		Mockito.verify(this.fieldbookMiddlewareService, Mockito.times(1)).loadObservations(Mockito.any(), ArgumentMatchers.eq(Arrays.asList(1,2,3)), ArgumentMatchers.eq(Collections.singletonList(1)));
 		final ArgumentCaptor<AdvancingStudy> advanceInfoCaptor = ArgumentCaptor.forClass(AdvancingStudy.class);
 		Mockito.verify(this.advancingSourceListFactory).createAdvancingSourceList(ArgumentMatchers.any(), advanceInfoCaptor.capture(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
@@ -347,7 +347,7 @@ public class AdvancingControllerTest {
 
 	@Test
 	public void testDeleteImportedGermplasmEntriesIfDeleted() {
-		List<ImportedGermplasm> importedGermplasms = new ArrayList<ImportedGermplasm>();
+		List<ImportedGermplasm> importedGermplasms = new ArrayList<>();
 		for (int i = 0; i < 10; i++) {
 			final ImportedGermplasm germplasm = new ImportedGermplasm();
 			germplasm.setEntryNumber(i);
@@ -359,7 +359,7 @@ public class AdvancingControllerTest {
 	}
 
 	private List<ImportedGermplasm> generateGermplasm() {
-		final List<ImportedGermplasm> importedGermplasms = new ArrayList<ImportedGermplasm>();
+		final List<ImportedGermplasm> importedGermplasms = new ArrayList<>();
 		for (int i = 0; i < 10; i++) {
 			final ImportedGermplasm germplasm = new ImportedGermplasm();
 			germplasm.setEntryNumber(i);
@@ -465,7 +465,7 @@ public class AdvancingControllerTest {
 
         advanceGermplasmChangeDetailList.add(advanceGermplasmChangeDetailUpdated);
 
-        return advanceGermplasmChangeDetailList.toArray(new AdvanceGermplasmChangeDetail[advanceGermplasmChangeDetailList.size()]);
+        return advanceGermplasmChangeDetailList.toArray(new AdvanceGermplasmChangeDetail[0]);
     }
 
     @Test
@@ -494,7 +494,7 @@ public class AdvancingControllerTest {
         this.assertGermPlasmList(listOfGermPlasm,0);
 
         Assert.assertEquals(10,form.getEntries());
-        Assert.assertEquals(123l,form.getUniqueId().longValue());
+        Assert.assertEquals(123L,form.getUniqueId().longValue());
 
     }
 
@@ -502,7 +502,7 @@ public class AdvancingControllerTest {
     public void testShowAdvanceNurseryThrowNumberFormatException(){
         final AdvancingStudyForm form = new AdvancingStudyForm();
         final String templateUrl = this.advancingController.showAdvanceStudy(form,null, this.request);
-
+		Assert.assertNotNull(templateUrl);
         Assert.assertEquals(0,form.getEntries());
         Assert.assertEquals(0,form.getGermplasmList().size());
 
@@ -529,7 +529,7 @@ public class AdvancingControllerTest {
         Assert.assertEquals(7,listOfGermPlasm.size());
         this.assertGermPlasmList(listOfGermPlasm,3);
         Assert.assertEquals(7,form.getEntries());
-        Assert.assertEquals(123l,form.getUniqueId().longValue());
+        Assert.assertEquals(123L,form.getUniqueId().longValue());
 
     }
 
@@ -537,7 +537,7 @@ public class AdvancingControllerTest {
     public void testDeleteAdvanceNurseryEntriesSuccessThrowNumberFormatException(){
         final AdvancingStudyForm form = new AdvancingStudyForm();
         final String templateUrl = this.advancingController.deleteAdvanceStudyEntries(form,null,this.request);
-
+        Assert.assertNotNull(templateUrl);
         Assert.assertEquals(0,form.getEntries());
         Assert.assertEquals(0,form.getGermplasmList().size());
 
@@ -548,7 +548,7 @@ public class AdvancingControllerTest {
         final Workbook workBook = new Workbook();
         workBook.setMeasurementDatesetId(2);
         Mockito.when(this.userSelection.getWorkbook()).thenReturn(workBook);
-        Mockito.when(this.fieldbookMiddlewareService.countPlotsWithRecordedVariatesInDataset(Mockito.anyInt(),Mockito.isA(List.class))).thenReturn(new Integer(2));
+        Mockito.when(this.fieldbookMiddlewareService.countPlotsWithRecordedVariatesInDataset(Mockito.anyInt(),Mockito.isA(List.class))).thenReturn(2);
         final int plotCount = this.advancingController.countPlots("1,2");
         Assert.assertEquals(2,plotCount);
 

--- a/src/test/java/com/efficio/fieldbook/web/util/ExpDesignUtilTest.java
+++ b/src/test/java/com/efficio/fieldbook/web/util/ExpDesignUtilTest.java
@@ -1,0 +1,34 @@
+package com.efficio.fieldbook.web.util;
+
+import org.generationcp.middleware.domain.etl.ExperimentalDesignVariable;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class ExpDesignUtilTest {
+
+    @Test
+    public void testExperimentalDesignValueNull() {
+        final ExperimentalDesignVariable experimentalDesignVariable = new ExperimentalDesignVariable(null);
+        final MeasurementVariable measurementVariable = new MeasurementVariable();
+        measurementVariable.setTermId(TermId.EXPERIMENT_DESIGN_FACTOR.getId());
+        measurementVariable.setValue(null);
+        Assert.assertEquals("Null Parameter should return zero value",0, ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(null));
+        Assert.assertEquals("Null Experiment Factor should return zero value", 0,  ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(experimentalDesignVariable));
+
+        experimentalDesignVariable.setVariables(Collections.singletonList(measurementVariable));
+        Assert.assertEquals("Null Experiment Factor value should return zero value", 0,  ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(experimentalDesignVariable));
+    }
+
+    @Test
+    public void testExperimentalDesign() {
+        final MeasurementVariable measurementVariable = new MeasurementVariable();
+        measurementVariable.setTermId(TermId.EXPERIMENT_DESIGN_FACTOR.getId());
+        measurementVariable.setValue(String.valueOf(TermId.P_REP.getId()));
+        final ExperimentalDesignVariable experimentalDesignVariable = new ExperimentalDesignVariable(Collections.singletonList(measurementVariable));
+        Assert.assertEquals(TermId.P_REP.getId(), ExpDesignUtil.getExperimentalDesignValueFromExperimentalDesignVariable(experimentalDesignVariable));
+    }
+}


### PR DESCRIPTION
if prep design, there is no REP_NO property in nd_experimentprop, causing the issue. 
When advancing a prep design, Reps filter will not show, we do this by not setting the attribute replicationsChoices 
Move getExperimentalDesignValueFromExperimentalDesignVariable to ExpDesignUtil 