### PR TITLE
Adding an IF condition so germplasm descriptors are added with Operat…

### DIFF
--- a/src/main/java/com/efficio/fieldbook/web/common/controller/ManageSettingsController.java
+++ b/src/main/java/com/efficio/fieldbook/web/common/controller/ManageSettingsController.java
@@ -258,7 +258,13 @@ public class ManageSettingsController extends SettingsController {
 			if (selectedVariables != null && !selectedVariables.isEmpty()) {
 
 				for (final SettingVariable settingVariable : selectedVariables) {
-					final Operation operation = this.removeVarFromDeletedList(settingVariable, mode);
+					final Operation operation;
+
+					if (VariableType.GERMPLASM_DESCRIPTOR.getId().equals(mode)) {
+						operation = Operation.UPDATE;
+					} else {
+						operation = this.removeVarFromDeletedList(settingVariable, mode);
+					}
 
 					settingVariable.setOperation(operation);
 


### PR DESCRIPTION
…ion = UPDATE. Germplasm descriptors are autosaved but at the same time they were added to the workbook with ADD operation so if in any operation the workbook was saved, then the germplasm descriptor was duplicated in the DB

IBP-4547