### PR TITLE
IBP-4994: Restore Observation cell auto-focus in update inline feature

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/subobservations/subObservationSet.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/subobservations/subObservationSet.js
@@ -1253,7 +1253,7 @@
 							 * This also avoids temporary click handler on body
 							 * FIXME is there a better way?
 							 */
-							$(cell).find('a.ui-select-match').click().focus();
+							$(cell).find('a.ui-select-match, input').click().focus();
 						}, 100);
 					});
 				} // clickHandler


### PR DESCRIPTION
Fix revert https://github.com/IntegratedBreedingPlatform/Fieldbook/commit/94b8edd9b1ac7b2d4c7775ee3576826360d59172#diff-ef0501f60ff990095420f36afe678b7a653555c2bccf538947a0dd1eac85eed7R1249
while reverting from https://github.com/IntegratedBreedingPlatform/Fieldbook/commit/19991edbf92770b8ed787c91ae52a50871aa3e21#diff-ef0501f60ff990095420f36afe678b7a653555c2bccf538947a0dd1eac85eed7R1240