### PR TITLE
IBP-5074: Error in creating lots because of duplicate in GIDs

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/trialmanager/crosses/crossing-settings-modal.js
+++ b/src/main/webapp/WEB-INF/static/js/trialmanager/crosses/crossing-settings-modal.js
@@ -32,7 +32,7 @@
 				startNumber: null,
 				saveParentageDesignationAsAString: false
 			},
-			preservePlotDuplicate: true,
+			preservePlotDuplicates: true,
 			applyNewGroupToPreviousCrosses: false,
 			isUseManualSettingsForNaming: false,
 			additionalDetailsSetting: {


### PR DESCRIPTION
- crosses are being merged (saved with the same GIDs) on importing duplicate plots because preservePlotDuplicates in settings is disabled (not set properly because of the attribute typo in js)